### PR TITLE
Version 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * `courier.CourierClient` has been renamed to `courier.CreateClient`
 * `courier.CreateClient` now takes a `nil` second parameter if you wish to use our default API URL, not `""`
-* Our underlying API communication functionas are now exposed via `client.API`
+* Our underlying API communication functions are now exposed via `client.API`
 * renamed `SendRequest` to `SendBody` and modified the struct
 * `Send` now takes one `body interface{}` argument rather than separate `profile` and `data` arguments
 * added `SendMap`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [v2.0.0] - 2020-06-24
+
+* `courier.CourierClient` has been renamed to `courier.CreateClient`
+* `courier.CreateClient` now takes a `nil` second parameter if you wish to use our default API URL, not `""`
+* Our underlying API communication functionas are now exposed via `client.API`
+* renamed `SendRequest` to `SendBody` and modified the struct
+* `Send` now takes one `body interface{}` argument rather than separate `profile` and `data` arguments
+* added `SendMap`
+* `GetProfile` now requires a `context` argument 
+* `GetProfile` now returns a `map[string]json.RawMessage{}` instead of hydrating a struct reference
+* renamed `MergeProfile` to `MergeProfileBytes`
+* `MergeProfileBytes` now requires a `context` argument
+* renamed `UpdateProfile` to `UpdateProfileBytes`
+* `UpdateProfileBytes` now requires a `context` argument

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,5 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * added `SendMap`
 * `GetProfile` now requires a `context` argument 
 * `GetProfile` now returns a `map[string]json.RawMessage{}` instead of hydrating a struct reference
-* renamed `MergeProfile` to `MergeProfileBytes`
-* `MergeProfileBytes` now requires a `context` argument
-* renamed `UpdateProfile` to `UpdateProfileBytes`
-* `UpdateProfileBytes` now requires a `context` argument
+* removed `MergeProfile`; use `client.API.SendRequestWithBytes(context.Background(), "PUT", "/profiles/"+recipientID, profile)` instead
+* removed `UpdateProfile`; use `client.API.SendRequestWithBytes(context.Background(), "PUT", "/profiles/"+recipientID, profile)` instead

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+PR's welcome:
+
+https://github.com/trycourier/courier-go
+
+## Releasing New Versions
+
+Make sure you have incremented the version string in `courier.go` to your new version string, hereafter referred to as `<VERSION>` and merged that commit. Then:
+
+```bash
+git tag -a v<VERSION> -m v<VERSION>
+git push origin v<VERSION>
+```

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ func mergeProfile() {
         }`)
 
         client := courier.CreateClient("<YOUR_AUTH_TOKEN>", nil)
-        err := client.MergeProfileBytes(context.Background(), recipientID, profile)
+        _, err = client.API.SendRequestWithBytes(context.Background(), "POST", "/profiles/"+recipientID, profile)
         if err != nil {
                 log.Fatalln(err)
         }
@@ -89,7 +89,7 @@ func updateProfile() {
         }`)
 
         client := courier.CreateClient("<YOUR_AUTH_TOKEN>", nil)
-        err := client.UpdateProfileBytes(context.Background(), recipientID, profile)
+        _, err = client.API.SendRequestWithBytes(context.Background(), "PUT", "/profiles/"+recipientID, profile)
         if err != nil {
                 log.Fatalln(err)
         }

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ func send() {
                 foo: "bar",
         }
 
-        client := courier.CourierClient(authToken, "https://api.trycourier.app")
+        client := courier.CreateClient(authToken, nil)
         messageID, err := client.Send(context.Background(), eventID, recipientID, profile, data)
         if err != nil {
                 log.Fatalln(err)
@@ -59,14 +59,14 @@ func main() {
 If you need to use a base url other than the default https://api.trycourier.app, you can pass it in as the second paramter to the `CourierClient`:
 
 ```go
-client := courier.CourierClient("<AUTH_TOKEN>", "<BASE_URL>")
+client := courier.CreateClient("<AUTH_TOKEN>", "<BASE_URL>")
 ```
 
 ## Advanced Usage
 
 ```go
 func getProfile() {
-        client := courier.CourierClient("<AUTH_TOKEN>")
+        client := courier.CreateClient("<AUTH_TOKEN>", nil)
         var recipientId = "<RECIPIENT_ID>"
         response, err := client.GetProfile(recipientId)
         if err != nil {
@@ -76,7 +76,7 @@ func getProfile() {
 }
 
 func mergeProfile() {
-        client := courier.CourierClient("<AUTH_TOKEN>")
+        client := courier.CreateClient("<AUTH_TOKEN>", nil)
         var profile = []byte(`{
                 profile: {
                         email: "example@example.com",
@@ -91,7 +91,7 @@ func mergeProfile() {
 }
 
 func updateProfile() {
-        client := courier.CourierClient("<AUTH_TOKEN>")
+        client := courier.CreateClient("<AUTH_TOKEN>", nil)
         var profile = []byte(`{
                 profile: {
                         email: "example@example.com",

--- a/README.md
+++ b/README.md
@@ -99,9 +99,6 @@ func updateProfile() {
 ## Staying Updated
 To update this SDK to the latest version, use `go get -u github.com/trycourier/courier-go`.
 
-## Contributing
-Bug reports and pull requests are welcome on GitHub at https://github.com/trycourier/courier-go.
-
 ## License
 The package is available as open source under the terms of the MIT License.
 [MIT License](http://www.opensource.org/licenses/mit-license.php)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ func mergeProfile() {
         }`)
 
         client := courier.CreateClient("<YOUR_AUTH_TOKEN>", nil)
-        err := client.MergeProfile(context.Background(), recipientID, profile)
+        err := client.MergeProfileBytes(context.Background(), recipientID, profile)
         if err != nil {
                 log.Fatalln(err)
         }
@@ -89,7 +89,7 @@ func updateProfile() {
         }`)
 
         client := courier.CreateClient("<YOUR_AUTH_TOKEN>", nil)
-        err := client.UpdateProfile(context.Background(), recipientID, profile)
+        err := client.UpdateProfileBytes(context.Background(), recipientID, profile)
         if err != nil {
                 log.Fatalln(err)
         }

--- a/README.md
+++ b/README.md
@@ -15,44 +15,30 @@ import "github.com/trycourier/courier-go"
 ## Usage
 
 ```go
-package main
-
-import (
-        "context
-        "log"
-
-        "github.com/trycourier/courier-go"
-)
-
-type profile struct {
-        Email string `json:"email"`
-}
-type data struct {
-        Foo string `json:"foo"`
-}
-
 func send() {
-        var authToken = "<YOUR_AUTH_TOKEN>"
-        var eventID = "<YOUR_EVENT_ID>"
-        var recipientID = "<YOUR_RECIPIENT_ID>"
-
-        profile := &profile{
-                email: "foo@example.com",
+        type profile struct {
+                Email string `json:"email"`
         }
-        data := &data{
-                foo: "bar",
+        type data struct {
+                Foo string `json:"foo"`
         }
 
-        client := courier.CreateClient(authToken, nil)
-        messageID, err := client.Send(context.Background(), eventID, recipientID, profile, data)
+        var eventID = "example-event"
+        var recipientID = "example-recipient"
+
+        client := courier.CreateClient("<YOUR_AUTH_TOKEN>", nil)
+        messageID, err := client.Send(context.Background(), eventID, recipientID, courier.SendBody{
+                profile{
+                        Email: "foo@example.com",
+                },
+                data{
+                        Foo: "bar",
+                },
+        })
         if err != nil {
                 log.Fatalln(err)
 	}
         log.Println(messageID)
-}
-
-func main() {
-        send()
 }
 ```
 
@@ -66,45 +52,52 @@ client := courier.CreateClient("<AUTH_TOKEN>", "<BASE_URL>")
 
 ```go
 func getProfile() {
-        client := courier.CreateClient("<AUTH_TOKEN>", nil)
-        var recipientId = "<RECIPIENT_ID>"
-        response, err := client.GetProfile(recipientId)
+        var recipientID = "<YOUR_RECIPIENT_ID>"
+
+        client := courier.CreateClient("<YOUR_AUTH_TOKEN>", nil)
+        response, err := client.GetProfile(context.Background(), recipientID)
         if err != nil {
                 log.Fatalln(err)
         }
+
         log.Println(response.Profile)
 }
 
 func mergeProfile() {
-        client := courier.CreateClient("<AUTH_TOKEN>", nil)
+        var recipientID = "<YOUR_RECIPIENT_ID>"
         var profile = []byte(`{
                 profile: {
                         email: "example@example.com",
                         phone_number: "555-228-3890"
-                },
-                data: {} // optional variables for merging into templates
+                }
         }`)
-        err := client.MergeProfile("<RECIPIENT_ID>", profile)
+
+        client := courier.CreateClient("<YOUR_AUTH_TOKEN>", nil)
+        err := client.MergeProfile(context.Background(), recipientID, profile)
         if err != nil {
                 log.Fatalln(err)
         }
 }
 
 func updateProfile() {
-        client := courier.CreateClient("<AUTH_TOKEN>", nil)
+        var recipientID = "<YOUR_RECIPIENT_ID>"
         var profile = []byte(`{
                 profile: {
                         email: "example@example.com",
                         phone_number: "555-228-3890"
-                },
-                data: {} // optional variables for merging into templates
+                }
         }`)
-        err := client.UpdateProfile("5957debf-5e16-499f-ab35-a614a87fded5", profile)
+
+        client := courier.CreateClient("<YOUR_AUTH_TOKEN>", nil)
+        err := client.UpdateProfile(context.Background(), recipientID, profile)
         if err != nil {
                 log.Fatalln(err)
         }
 }
 ```
+
+## Staying Updated
+To update this SDK to the latest version, use `go get -u github.com/trycourier/courier-go`.
 
 ## Contributing
 Bug reports and pull requests are welcome on GitHub at https://github.com/trycourier/courier-go.

--- a/api/request.go
+++ b/api/request.go
@@ -1,4 +1,4 @@
-package http
+package api
 
 import (
 	"bytes"
@@ -10,15 +10,28 @@ import (
 	"net/http"
 )
 
-// APIConfiguration represents the core data needed to communicate with the Courier API
-type APIConfiguration struct {
+// Configuration represents the core data needed to communicate with the Courier API
+type Configuration struct {
 	AuthToken  string
 	BaseURL    string
 	SDKVersion string
 }
 
+// HTTPError is a customer error returned when the API doesn't respond with a 2XX
+type HTTPError struct {
+	StatusCode   int
+	ErrorMessage *string
+}
+
+func (err *HTTPError) Error() string {
+	if err.ErrorMessage == nil {
+		return fmt.Sprintf("HTTP Error %d: %s", err.StatusCode, "<no HTTP body>")
+	}
+	return fmt.Sprintf("HTTP Error %d: %s", err.StatusCode, *err.ErrorMessage)
+}
+
 // SendRequestWithJSON wraps HTTPSendBytes
-func (api *APIConfiguration) SendRequestWithJSON(ctx context.Context, method string, relativePath string, body interface{}, response interface{}) error {
+func (api *Configuration) SendRequestWithJSON(ctx context.Context, method string, relativePath string, body interface{}, response interface{}) error {
 	jsonBody, err := json.Marshal(body)
 	if err != nil {
 		return err
@@ -38,7 +51,7 @@ func (api *APIConfiguration) SendRequestWithJSON(ctx context.Context, method str
 }
 
 // SendRequestWithMaps wraps HTTPSendBytes
-func (api *APIConfiguration) SendRequestWithMaps(ctx context.Context, method string, relativePath string, body map[string]interface{}) (map[string]json.RawMessage, error) {
+func (api *Configuration) SendRequestWithMaps(ctx context.Context, method string, relativePath string, body map[string]interface{}) (map[string]json.RawMessage, error) {
 	jsonBody, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
@@ -58,14 +71,14 @@ func (api *APIConfiguration) SendRequestWithMaps(ctx context.Context, method str
 }
 
 // SendRequestWithBytes wraps SendRequestWithReader
-func (api *APIConfiguration) SendRequestWithBytes(ctx context.Context, method string, relativePath string, body []byte) ([]byte, error) {
+func (api *Configuration) SendRequestWithBytes(ctx context.Context, method string, relativePath string, body []byte) ([]byte, error) {
 	// buf := bytes.NewBuffer(body)
 	buf := bytes.NewReader(body)
 	return api.SendRequestWithReader(ctx, method, relativePath, buf)
 }
 
 // SendRequestWithReader wraps HTTPRequest
-func (api *APIConfiguration) SendRequestWithReader(ctx context.Context, method string, relativePath string, body io.Reader) ([]byte, error) {
+func (api *Configuration) SendRequestWithReader(ctx context.Context, method string, relativePath string, body io.Reader) ([]byte, error) {
 	fullyQualifiedURL := api.BaseURL + relativePath
 	req, err := http.NewRequestWithContext(ctx, method, fullyQualifiedURL, body)
 	if err != nil {
@@ -75,7 +88,7 @@ func (api *APIConfiguration) SendRequestWithReader(ctx context.Context, method s
 }
 
 // ExecuteRequest issues an HTTP request and sets headers expected by the Courier API
-func (api *APIConfiguration) ExecuteRequest(req *http.Request) ([]byte, error) {
+func (api *Configuration) ExecuteRequest(req *http.Request) ([]byte, error) {
 	req.Header.Set("Authorization", "Bearer "+api.AuthToken)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "courier-go/"+api.SDKVersion)
@@ -94,7 +107,8 @@ func (api *APIConfiguration) ExecuteRequest(req *http.Request) ([]byte, error) {
 	}
 
 	if http.StatusOK != resp.StatusCode {
-		return nil, fmt.Errorf("%s", body)
+		errMessage := string(body[:])
+		return nil, &HTTPError{resp.StatusCode, &errMessage}
 	}
 	return body, nil
 }

--- a/courier.go
+++ b/courier.go
@@ -6,7 +6,7 @@ const version = "2.0.0"
 
 // Client lets you communicate with the Courier API
 type Client struct {
-	http *http.APIConfiguration
+	API *http.APIConfiguration
 }
 
 // CreateClient creates a new client for communicating with the Courier API
@@ -19,7 +19,7 @@ func CreateClient(authToken string, baseURL *string) *Client {
 	}
 
 	return &Client{
-		http: &http.APIConfiguration{
+		API: &http.APIConfiguration{
 			AuthToken:  authToken,
 			BaseURL:    url,
 			SDKVersion: version,

--- a/courier.go
+++ b/courier.go
@@ -1,89 +1,28 @@
 package courier
 
-import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"io/ioutil"
-	"net/http"
-)
+import "github.com/trycourier/courier-go/http"
 
 const version = "2.0.0"
 
-// Client represents the core data needed to communicate with the Courier API
+// Client lets you communicate with the Courier API
 type Client struct {
-	AuthToken  string
-	BaseURL    string
-	SDKVersion string
+	http *http.APIConfiguration
 }
 
 // CreateClient creates a new client for communicating with the Courier API
 func CreateClient(authToken string, baseURL *string) *Client {
+	var url string
 	if baseURL == nil {
-		return &Client{
-			AuthToken:  authToken,
-			BaseURL:    "https://api.trycourier.app",
-			SDKVersion: version,
-		}
+		url = "https://api.trycourier.app"
+	} else {
+		url = *baseURL
 	}
 
-	deref := *baseURL
 	return &Client{
-		AuthToken:  authToken,
-		BaseURL:    deref,
-		SDKVersion: version,
+		http: &http.APIConfiguration{
+			AuthToken:  authToken,
+			BaseURL:    url,
+			SDKVersion: version,
+		},
 	}
-}
-
-// HTTPSendJSON wraps HTTPSendBytes
-func (c *Client) HTTPSendJSON(ctx context.Context, method string, url string, body interface{}, response interface{}) error {
-	jsonBody, err := json.Marshal(body)
-	if err != nil {
-		return err
-	}
-
-	bytes, err := c.HTTPSendBytes(ctx, method, url, bytes.NewReader(jsonBody))
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(bytes, &response)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// HTTPSendBytes wraps HTTPRequest
-func (c *Client) HTTPSendBytes(ctx context.Context, method string, url string, body io.Reader) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+url, body)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.HTTPRequest(req)
-}
-
-// HTTPRequest issues an HTTP request and sets headers expected by the Courier API
-func (c *Client) HTTPRequest(req *http.Request) ([]byte, error) {
-	req.Header.Set("Authorization", "Bearer "+c.AuthToken)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "courier-go/"+c.SDKVersion)
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	if http.StatusOK != resp.StatusCode {
-		return nil, fmt.Errorf("%s", body)
-	}
-	return body, nil
 }

--- a/courier.go
+++ b/courier.go
@@ -1,12 +1,12 @@
 package courier
 
-import "github.com/trycourier/courier-go/http"
+import "github.com/trycourier/courier-go/api"
 
 const version = "2.0.0"
 
 // Client lets you communicate with the Courier API
 type Client struct {
-	API *http.APIConfiguration
+	API *api.Configuration
 }
 
 // CreateClient creates a new client for communicating with the Courier API
@@ -19,7 +19,7 @@ func CreateClient(authToken string, baseURL *string) *Client {
 	}
 
 	return &Client{
-		API: &http.APIConfiguration{
+		API: &api.Configuration{
 			AuthToken:  authToken,
 			BaseURL:    url,
 			SDKVersion: version,

--- a/courier.go
+++ b/courier.go
@@ -1,30 +1,77 @@
 package courier
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 )
 
+const version = "2.0.0"
+
+// Client represents the core data needed to communicate with the Courier API
 type Client struct {
-	ApiKey  string
-	BaseUrl string
+	AuthToken  string
+	BaseURL    string
+	SDKVersion string
 }
 
-func CourierClient(apiKey string, baseUrl string) *Client {
-	if baseUrl == "" {
-		baseUrl = "https://api.trycourier.app"
+// CreateClient creates a new client for communicating with the Courier API
+func CreateClient(authToken string, baseURL *string) *Client {
+	if baseURL == nil {
+		return &Client{
+			AuthToken:  authToken,
+			BaseURL:    "https://api.trycourier.app",
+			SDKVersion: version,
+		}
 	}
+
+	deref := *baseURL
 	return &Client{
-		ApiKey:  apiKey,
-		BaseUrl: baseUrl,
+		AuthToken:  authToken,
+		BaseURL:    deref,
+		SDKVersion: version,
 	}
 }
 
-func (s *Client) doRequest(req *http.Request) ([]byte, error) {
-	req.Header.Set("Authorization", "Bearer "+s.ApiKey)
+// HTTPSendJSON wraps HTTPSendBytes
+func (c *Client) HTTPSendJSON(ctx context.Context, method string, url string, body interface{}, response interface{}) error {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	bytes, err := c.HTTPSendBytes(ctx, method, url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(bytes, &response)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// HTTPSendBytes wraps HTTPRequest
+func (c *Client) HTTPSendBytes(ctx context.Context, method string, url string, body io.Reader) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.HTTPRequest(req)
+}
+
+// HTTPRequest issues an HTTP request and sets headers expected by the Courier API
+func (c *Client) HTTPRequest(req *http.Request) ([]byte, error) {
+	req.Header.Set("Authorization", "Bearer "+c.AuthToken)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "courier-go/0.0.1")
+	req.Header.Set("User-Agent", "courier-go/"+c.SDKVersion)
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/http/request.go
+++ b/http/request.go
@@ -1,0 +1,74 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+// APIConfiguration represents the core data needed to communicate with the Courier API
+type APIConfiguration struct {
+	AuthToken  string
+	BaseURL    string
+	SDKVersion string
+}
+
+// SendRequestWithJSON wraps HTTPSendBytes
+func (api *APIConfiguration) SendRequestWithJSON(ctx context.Context, method string, relativePath string, body interface{}, response interface{}) error {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	bytes, err := api.SendRequestWithBytes(ctx, method, relativePath, bytes.NewReader(jsonBody))
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(bytes, &response)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SendRequestWithBytes wraps HTTPRequest
+func (api *APIConfiguration) SendRequestWithBytes(ctx context.Context, method string, relativePath string, body io.Reader) ([]byte, error) {
+	fullyQualifiedURL := api.BaseURL + relativePath
+	req, err := http.NewRequestWithContext(ctx, method, fullyQualifiedURL, body)
+	if err != nil {
+		return nil, err
+	}
+
+	return api.ExecuteRequest(req)
+}
+
+// ExecuteRequest issues an HTTP request and sets headers expected by the Courier API
+func (api *APIConfiguration) ExecuteRequest(req *http.Request) ([]byte, error) {
+	req.Header.Set("Authorization", "Bearer "+api.AuthToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "courier-go/"+api.SDKVersion)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if http.StatusOK != resp.StatusCode {
+		return nil, fmt.Errorf("%s", body)
+	}
+	return body, nil
+}

--- a/http/request.go
+++ b/http/request.go
@@ -24,7 +24,7 @@ func (api *APIConfiguration) SendRequestWithJSON(ctx context.Context, method str
 		return err
 	}
 
-	bytes, err := api.SendRequestWithBytes(ctx, method, relativePath, bytes.NewReader(jsonBody))
+	bytes, err := api.SendRequestWithBytes(ctx, method, relativePath, jsonBody)
 	if err != nil {
 		return err
 	}
@@ -44,7 +44,7 @@ func (api *APIConfiguration) SendRequestWithMaps(ctx context.Context, method str
 		return nil, err
 	}
 
-	bytes, err := api.SendRequestWithBytes(ctx, method, relativePath, bytes.NewReader(jsonBody))
+	bytes, err := api.SendRequestWithBytes(ctx, method, relativePath, jsonBody)
 	if err != nil {
 		return nil, err
 	}
@@ -57,8 +57,15 @@ func (api *APIConfiguration) SendRequestWithMaps(ctx context.Context, method str
 	return objmap, nil
 }
 
-// SendRequestWithBytes wraps HTTPRequest
-func (api *APIConfiguration) SendRequestWithBytes(ctx context.Context, method string, relativePath string, body io.Reader) ([]byte, error) {
+// SendRequestWithBytes wraps SendRequestWithReader
+func (api *APIConfiguration) SendRequestWithBytes(ctx context.Context, method string, relativePath string, body []byte) ([]byte, error) {
+	// buf := bytes.NewBuffer(body)
+	buf := bytes.NewReader(body)
+	return api.SendRequestWithReader(ctx, method, relativePath, buf)
+}
+
+// SendRequestWithReader wraps HTTPRequest
+func (api *APIConfiguration) SendRequestWithReader(ctx context.Context, method string, relativePath string, body io.Reader) ([]byte, error) {
 	fullyQualifiedURL := api.BaseURL + relativePath
 	req, err := http.NewRequestWithContext(ctx, method, fullyQualifiedURL, body)
 	if err != nil {

--- a/http/request.go
+++ b/http/request.go
@@ -37,6 +37,26 @@ func (api *APIConfiguration) SendRequestWithJSON(ctx context.Context, method str
 	return nil
 }
 
+// SendRequestWithMaps wraps HTTPSendBytes
+func (api *APIConfiguration) SendRequestWithMaps(ctx context.Context, method string, relativePath string, body map[string]interface{}) (map[string]json.RawMessage, error) {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	bytes, err := api.SendRequestWithBytes(ctx, method, relativePath, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, err
+	}
+
+	var objmap map[string]json.RawMessage
+	err = json.Unmarshal(bytes, &objmap)
+	if err != nil {
+		return nil, err
+	}
+	return objmap, nil
+}
+
 // SendRequestWithBytes wraps HTTPRequest
 func (api *APIConfiguration) SendRequestWithBytes(ctx context.Context, method string, relativePath string, body io.Reader) ([]byte, error) {
 	fullyQualifiedURL := api.BaseURL + relativePath
@@ -44,7 +64,6 @@ func (api *APIConfiguration) SendRequestWithBytes(ctx context.Context, method st
 	if err != nil {
 		return nil, err
 	}
-
 	return api.ExecuteRequest(req)
 }
 

--- a/lib.go
+++ b/lib.go
@@ -1,0 +1,18 @@
+package courier
+
+import "encoding/json"
+
+func toJSONMap(input interface{}) (map[string]interface{}, error) {
+	var m map[string]interface{}
+	temp, err := json.Marshal(input)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(temp, &m)
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}

--- a/messages.go
+++ b/messages.go
@@ -2,7 +2,6 @@ package courier
 
 import (
 	"context"
-	"fmt"
 )
 
 // ProvidersChannelResponse represents the channel section of the ProvidersResponse
@@ -43,11 +42,9 @@ type MessageResponse struct {
 // GetMessage calls the /messages/:id endpoint of the Courier API
 func (c *Client) GetMessage(ctx context.Context, messageID string) (*MessageResponse, error) {
 	var response MessageResponse
-
-	err := c.HTTPSendJSON(ctx, "GET", fmt.Sprintf("/messages/%s", messageID), nil, &response)
+	err := c.http.SendRequestWithJSON(ctx, "GET", "/messages/"+messageID, nil, &response)
 	if err != nil {
 		return nil, err
 	}
-
 	return &response, nil
 }

--- a/messages.go
+++ b/messages.go
@@ -2,61 +2,52 @@ package courier
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
+// ProvidersChannelResponse represents the channel section of the ProvidersResponse
 type ProvidersChannelResponse struct {
-	Key string
-	Name string
+	Key      string
+	Name     string
 	Template string
 }
+
+// ProvidersResponse represents the providers section of the MessageResponse
 type ProvidersResponse struct {
-	Channel *ProvidersChannelResponse
-	Error string
-	Status string
+	Channel   *ProvidersChannelResponse
+	Error     string
+	Status    string
 	Delivered int64
-	Sent int64
-	Clicked int64
-	Provider string
+	Sent      int64
+	Clicked   int64
+	Provider  string
 	Reference interface{} // provider specific response
 }
 
+// MessageResponse represents the return of the /messages/* endpoints on the Courier API
 type MessageResponse struct {
-	Id string
-	Event string
+	ID           string
+	Event        string
 	Notification string
-	Status string
-	Error string
-	Reason string
-	Recipient string
-	Enqueued int64
-	Delivered int64
-	Sent int64
-	Clicked int64
-	Providers []*ProvidersResponse
+	Status       string
+	Error        string
+	Reason       string
+	Recipient    string
+	Enqueued     int64
+	Delivered    int64
+	Sent         int64
+	Clicked      int64
+	Providers    []*ProvidersResponse
 }
 
+// GetMessage calls the /messages/:id endpoint of the Courier API
 func (c *Client) GetMessage(ctx context.Context, messageID string) (*MessageResponse, error) {
+	var response MessageResponse
 
-	url := fmt.Sprintf(c.BaseUrl+"/messages/%s", messageID)
-
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	err := c.HTTPSendJSON(ctx, "GET", fmt.Sprintf("/messages/%s", messageID), nil, &response)
 	if err != nil {
 		return nil, err
 	}
 
-	bytes, err := c.doRequest(req)
-	if err != nil {
-		return nil, err
-	}
-
-	var data MessageResponse
-	err = json.Unmarshal(bytes, &data)
-	if err != nil {
-		return nil, err
-	}
-
-	return &data, nil
+	return &response, nil
 }

--- a/messages.go
+++ b/messages.go
@@ -42,7 +42,7 @@ type MessageResponse struct {
 // GetMessage calls the /messages/:id endpoint of the Courier API
 func (c *Client) GetMessage(ctx context.Context, messageID string) (*MessageResponse, error) {
 	var response MessageResponse
-	err := c.http.SendRequestWithJSON(ctx, "GET", "/messages/"+messageID, nil, &response)
+	err := c.API.SendRequestWithJSON(ctx, "GET", "/messages/"+messageID, nil, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/messages_test.go
+++ b/messages_test.go
@@ -21,6 +21,7 @@ func TestMessages_GetMessage(t *testing.T) {
 		func(rw http.ResponseWriter, req *http.Request) {
 			assert.Equal(t, url, req.URL.String())
 
+			rw.WriteHeader(http.StatusOK)
 			rw.Header().Add("Content-Type", "application/json")
 			rsp := `
 				{

--- a/messages_test.go
+++ b/messages_test.go
@@ -11,59 +11,58 @@ import (
 	"github.com/trycourier/courier-go"
 )
 
-func TestClient_GetMessage(t *testing.T) {
-
+func TestMessages_GetMessage(t *testing.T) {
 	requestMessageID := "1-23456789"
 	status := "CLICKED"
 	sent := int64(1589563865697)
+	url := "/messages/" + requestMessageID
 
 	server := httptest.NewServer(http.HandlerFunc(
-
 		func(rw http.ResponseWriter, req *http.Request) {
-
-			assert.Equal(t, "/messages/"+requestMessageID, req.URL.String())
+			assert.Equal(t, url, req.URL.String())
 
 			rw.Header().Add("Content-Type", "application/json")
 			rsp := `
-			{
-  				"id": "%s",
-  				"clicked": 1589563890843,
-  				"delivered": 1589563972000,
-  				"enqueued": 1589563863773,
-  				"event": "GEFGNB2GNQ4MZVHW4WV4R8Q8ZVN5",
-  				"notification": "GEFGNB2GNQ4MZVHW4WV4R8Q8ZVN5",
-  				"providers": [
 				{
-      				"channel": {
-        				"key": "sendgrid",
-        				"template": "5e95b992-3505-4f66-8808-f91d5d0fe8c9"
-      				},
-      				"clicked": 1589563890843,
-      				"delivered": 1589563972000,
-      				"provider": "sendgrid",
-      				"reference": {
-        			"message_id": "Xx14o44jToS8StSTPLGsTw.filterdrecv-p3iad2-8ddf98858-7qsdm-19-5EBED1D9-D3.0",
-        			"x-message-id": "Xx14o44jToS8StSTPLGsTw"
-					},
-      				"sent": 1589563865697,
-      				"status": "DELIVERED"
-    			}
-  				],
-  				"recipient": "tony@trycourier.com",
-  				"sent": %d,
-  				"status": "%s"
-			}`
+					"id": "%s",
+					"clicked": 1589563890843,
+					"delivered": 1589563972000,
+					"enqueued": 1589563863773,
+					"event": "GEFGNB2GNQ4MZVHW4WV4R8Q8ZVN5",
+					"notification": "GEFGNB2GNQ4MZVHW4WV4R8Q8ZVN5",
+					"providers": [
+						{
+							"channel": {
+								"key": "sendgrid",
+								"template": "5e95b992-3505-4f66-8808-f91d5d0fe8c9"
+							},
+							"clicked": 1589563890843,
+							"delivered": 1589563972000,
+							"provider": "sendgrid",
+							"reference": {
+								"message_id": "Xx14o44jToS8StSTPLGsTw.filterdrecv-p3iad2-8ddf98858-7qsdm-19-5EBED1D9-D3.0",
+								"x-message-id": "Xx14o44jToS8StSTPLGsTw"
+							},
+							"sent": 1589563865697,
+							"status": "DELIVERED"
+						}
+					],
+					"recipient": "tony@trycourier.com",
+					"sent": %d,
+					"status": "%s"
+				}`
 			_, _ = rw.Write([]byte(fmt.Sprintf(rsp, requestMessageID, sent, status)))
-
-		}))
+		}),
+	)
 	defer server.Close()
 
 	t.Run("makes requests for message ID", func(t *testing.T) {
 		client := courier.CreateClient("key", &server.URL)
-		rsp, err := client.GetMessage(context.Background(), requestMessageID)
+		response, err := client.GetMessage(context.Background(), requestMessageID)
 		assert.Nil(t, err)
-		assert.Equal(t, requestMessageID, rsp.ID)
-		assert.Equal(t, sent, rsp.Sent)
-		assert.Equal(t, status, rsp.Status)
+
+		assert.Equal(t, requestMessageID, response.ID)
+		assert.Equal(t, sent, response.Sent)
+		assert.Equal(t, status, response.Status)
 	})
 }

--- a/messages_test.go
+++ b/messages_test.go
@@ -59,10 +59,10 @@ func TestClient_GetMessage(t *testing.T) {
 	defer server.Close()
 
 	t.Run("makes requests for message ID", func(t *testing.T) {
-		client := courier.CourierClient("key", server.URL)
+		client := courier.CreateClient("key", &server.URL)
 		rsp, err := client.GetMessage(context.Background(), requestMessageID)
 		assert.Nil(t, err)
-		assert.Equal(t, requestMessageID, rsp.Id)
+		assert.Equal(t, requestMessageID, rsp.ID)
 		assert.Equal(t, sent, rsp.Sent)
 		assert.Equal(t, status, rsp.Status)
 	})

--- a/profiles.go
+++ b/profiles.go
@@ -1,28 +1,23 @@
 package courier
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 )
 
 // GetProfile calls the GET /profiles/:id endpoint of the Courier API
 func (c *Client) GetProfile(ctx context.Context, id string) (map[string]json.RawMessage, error) {
-	response, err := c.http.SendRequestWithMaps(ctx, "GET", "/profiles/"+id, nil)
-	if err != nil {
-		return nil, err
-	}
-	return response, nil
+	return c.API.SendRequestWithMaps(ctx, "GET", "/profiles/"+id, nil)
 }
 
-// MergeProfile calls the POST /profiles/:id endpoint of the Courier API
-func (c *Client) MergeProfile(ctx context.Context, id string, profile []byte) error {
-	_, err := c.http.SendRequestWithBytes(ctx, "POST", "/profiles/"+id, bytes.NewBuffer(profile))
+// MergeProfileBytes calls the POST /profiles/:id endpoint of the Courier API
+func (c *Client) MergeProfileBytes(ctx context.Context, id string, profile []byte) error {
+	_, err := c.API.SendRequestWithBytes(ctx, "POST", "/profiles/"+id, profile)
 	return err
 }
 
-// UpdateProfile calls the PUT /profiles/:id endpoint of the Courier API
-func (c *Client) UpdateProfile(ctx context.Context, id string, profile []byte) error {
-	_, err := c.http.SendRequestWithBytes(ctx, "PUT", "/profiles/"+id, bytes.NewBuffer(profile))
+// UpdateProfileBytes calls the PUT /profiles/:id endpoint of the Courier API
+func (c *Client) UpdateProfileBytes(ctx context.Context, id string, profile []byte) error {
+	_, err := c.API.SendRequestWithBytes(ctx, "PUT", "/profiles/"+id, profile)
 	return err
 }

--- a/profiles.go
+++ b/profiles.go
@@ -2,49 +2,43 @@ package courier
 
 import (
 	"bytes"
-	"encoding/json"
+	"context"
 	"fmt"
 	"net/http"
 )
 
+// Profile represents the return of the Courier profiles API
 type Profile struct {
 	Profile interface{} `json:"profile"`
 }
 
-func (s *Client) GetProfile(id string) (*Profile, error) {
-	url := fmt.Sprintf(s.BaseUrl+"/profiles/%s", id)
-	req, err := http.NewRequest("GET", url, nil)
+// GetProfile calls the GET /profiles/:id endpoint of the Courier API
+func (c *Client) GetProfile(ctx context.Context, id string) (*Profile, error) {
+	var response Profile
+	err := c.HTTPSendJSON(ctx, "GET", fmt.Sprintf("/profiles/%s", id), nil, &response)
 	if err != nil {
 		return nil, err
 	}
-	bytes, err := s.doRequest(req)
-	if err != nil {
-		return nil, err
-	}
-	var data Profile
-	err = json.Unmarshal(bytes, &data)
-	if err != nil {
-		return nil, err
-	}
-	return &data, nil
+	return &response, nil
 }
 
-func (s *Client) MergeProfile(id string, profile []byte) error {
-	url := fmt.Sprintf(s.BaseUrl+"/profiles/%s", id)
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(profile))
+// MergeProfile calls the POST /profiles/:id endpoint of the Courier API
+func (c *Client) MergeProfile(ctx context.Context, id string, profile []byte) error {
+	req, err := http.NewRequest("POST", fmt.Sprintf("/profiles/%s", id), bytes.NewBuffer(profile))
 	if err != nil {
 		return err
 	}
-	_, err = s.doRequest(req)
+	_, err = c.HTTPRequest(req)
 	return err
 }
 
-func (s *Client) UpdateProfile(id string, profile []byte) error {
-	url := fmt.Sprintf(s.BaseUrl+"/profiles/%s", id)
+// UpdateProfile calls the PUT /profiles/:id endpoint of the Courier API
+func (c *Client) UpdateProfile(ctx context.Context, id string, profile []byte) error {
+	url := fmt.Sprintf(c.BaseURL+"/profiles/%s", id)
 	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(profile))
 	if err != nil {
 		return err
 	}
-	_, err = s.doRequest(req)
+	_, err = c.HTTPRequest(req)
 	return err
 }

--- a/profiles.go
+++ b/profiles.go
@@ -3,7 +3,6 @@ package courier
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net/http"
 )
 
@@ -15,7 +14,7 @@ type Profile struct {
 // GetProfile calls the GET /profiles/:id endpoint of the Courier API
 func (c *Client) GetProfile(ctx context.Context, id string) (*Profile, error) {
 	var response Profile
-	err := c.HTTPSendJSON(ctx, "GET", fmt.Sprintf("/profiles/%s", id), nil, &response)
+	err := c.http.SendRequestWithJSON(ctx, "GET", "/profiles/"+id, nil, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -24,21 +23,20 @@ func (c *Client) GetProfile(ctx context.Context, id string) (*Profile, error) {
 
 // MergeProfile calls the POST /profiles/:id endpoint of the Courier API
 func (c *Client) MergeProfile(ctx context.Context, id string, profile []byte) error {
-	req, err := http.NewRequest("POST", fmt.Sprintf("/profiles/%s", id), bytes.NewBuffer(profile))
+	req, err := http.NewRequest("POST", c.http.BaseURL+"/profiles/"+id, bytes.NewBuffer(profile))
 	if err != nil {
 		return err
 	}
-	_, err = c.HTTPRequest(req)
+	_, err = c.http.ExecuteRequest(req)
 	return err
 }
 
 // UpdateProfile calls the PUT /profiles/:id endpoint of the Courier API
 func (c *Client) UpdateProfile(ctx context.Context, id string, profile []byte) error {
-	url := fmt.Sprintf(c.BaseURL+"/profiles/%s", id)
-	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(profile))
+	req, err := http.NewRequest("PUT", c.http.BaseURL+"/profiles/"+id, bytes.NewBuffer(profile))
 	if err != nil {
 		return err
 	}
-	_, err = c.HTTPRequest(req)
+	_, err = c.http.ExecuteRequest(req)
 	return err
 }

--- a/profiles.go
+++ b/profiles.go
@@ -3,40 +3,26 @@ package courier
 import (
 	"bytes"
 	"context"
-	"net/http"
+	"encoding/json"
 )
 
-// Profile represents the return of the Courier profiles API
-type Profile struct {
-	Profile interface{} `json:"profile"`
-}
-
 // GetProfile calls the GET /profiles/:id endpoint of the Courier API
-func (c *Client) GetProfile(ctx context.Context, id string) (*Profile, error) {
-	var response Profile
-	err := c.http.SendRequestWithJSON(ctx, "GET", "/profiles/"+id, nil, &response)
+func (c *Client) GetProfile(ctx context.Context, id string) (map[string]json.RawMessage, error) {
+	response, err := c.http.SendRequestWithMaps(ctx, "GET", "/profiles/"+id, nil)
 	if err != nil {
 		return nil, err
 	}
-	return &response, nil
+	return response, nil
 }
 
 // MergeProfile calls the POST /profiles/:id endpoint of the Courier API
 func (c *Client) MergeProfile(ctx context.Context, id string, profile []byte) error {
-	req, err := http.NewRequest("POST", c.http.BaseURL+"/profiles/"+id, bytes.NewBuffer(profile))
-	if err != nil {
-		return err
-	}
-	_, err = c.http.ExecuteRequest(req)
+	_, err := c.http.SendRequestWithBytes(ctx, "POST", "/profiles/"+id, bytes.NewBuffer(profile))
 	return err
 }
 
 // UpdateProfile calls the PUT /profiles/:id endpoint of the Courier API
 func (c *Client) UpdateProfile(ctx context.Context, id string, profile []byte) error {
-	req, err := http.NewRequest("PUT", c.http.BaseURL+"/profiles/"+id, bytes.NewBuffer(profile))
-	if err != nil {
-		return err
-	}
-	_, err = c.http.ExecuteRequest(req)
+	_, err := c.http.SendRequestWithBytes(ctx, "PUT", "/profiles/"+id, bytes.NewBuffer(profile))
 	return err
 }

--- a/profiles_test.go
+++ b/profiles_test.go
@@ -14,10 +14,6 @@ import (
 	"github.com/trycourier/courier-go"
 )
 
-// type TestResponseProfile struct {
-// 	Foo string `json:"foo"`
-// }
-
 func TestProfiles_GetProfile(t *testing.T) {
 	profileID := "example"
 	foo := "bar"

--- a/profiles_test.go
+++ b/profiles_test.go
@@ -1,0 +1,50 @@
+package courier_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/trycourier/courier-go"
+)
+
+// type TestResponseProfile struct {
+// 	Foo string `json:"foo"`
+// }
+
+func TestProfiles_GetProfile(t *testing.T) {
+	profileID := "example"
+	foo := "bar"
+	url := "/profiles/" + profileID
+
+	server := httptest.NewServer(http.HandlerFunc(
+		func(rw http.ResponseWriter, req *http.Request) {
+			assert.Equal(t, url, req.URL.String())
+			rw.Header().Add("Content-Type", "application/json")
+			rsp := `
+				{
+					"profile": {
+						"foo": "%s"
+					}
+				}`
+			_, _ = rw.Write([]byte(fmt.Sprintf(rsp, foo)))
+		}),
+	)
+	defer server.Close()
+
+	t.Run("makes requests for message ID", func(t *testing.T) {
+		client := courier.CreateClient("key", &server.URL)
+		response, err := client.GetProfile(context.Background(), profileID)
+		assert.Nil(t, err)
+
+		var profile map[string]string
+		err = json.Unmarshal(response["profile"], &profile)
+		assert.Nil(t, err)
+
+		assert.Equal(t, "bar", profile["foo"])
+	})
+}

--- a/profiles_test.go
+++ b/profiles_test.go
@@ -22,6 +22,7 @@ func TestProfiles_GetProfile(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(
 		func(rw http.ResponseWriter, req *http.Request) {
 			assert.Equal(t, url, req.URL.String())
+			rw.WriteHeader(http.StatusOK)
 			rw.Header().Add("Content-Type", "application/json")
 			rsp := `
 				{
@@ -47,7 +48,7 @@ func TestProfiles_GetProfile(t *testing.T) {
 	})
 }
 
-func TestProfiles_MergeProfileBytes(t *testing.T) {
+func TestProfiles_ProfilePOST(t *testing.T) {
 	type RequestBody struct {
 		Profile interface{}
 	}
@@ -71,6 +72,7 @@ func TestProfiles_MergeProfileBytes(t *testing.T) {
 				t.Error(err)
 			}
 
+			rw.WriteHeader(http.StatusOK)
 			rw.Header().Add("Content-Type", "application/json")
 			_, writeErr := rw.Write([]byte(fmt.Sprintf("{ \"status\" : \"%s\" }", "SUCCESS")))
 			if writeErr != nil {
@@ -93,7 +95,7 @@ func TestProfiles_MergeProfileBytes(t *testing.T) {
 		}
 
 		client := courier.CreateClient("key", &server.URL)
-		err = client.MergeProfileBytes(context.Background(), recipientID, bytes)
+		_, err = client.API.SendRequestWithBytes(context.Background(), "POST", "/profiles/"+recipientID, bytes)
 
 		assert.Nil(t, err)
 	})

--- a/send.go
+++ b/send.go
@@ -2,37 +2,43 @@ package courier
 
 import (
 	"context"
+	"encoding/json"
 )
 
-// SendRequest is the JSON body expected by Courier's /send endpoint
-type SendRequest struct {
-	EventID   string      `json:"event"`
-	Recipient string      `json:"recipient"`
-	Profile   interface{} `json:"profile"`
-	Data      interface{} `json:"data"`
+// SendBody is the JSON body expected by Courier's /send endpoint
+type SendBody struct {
+	Profile interface{} `json:"profile"`
+	Data    interface{} `json:"data"`
 }
 
-// SendResponse is the response returned by the CourierAPI upon success
-type SendResponse struct {
-	MessageID string `json:"messageId"`
-}
-
-// Send calls the /send endpoint of the Courier API
-func (c *Client) Send(ctx context.Context, eventID, recipientID string, profile, data interface{}) (string, error) {
-	payload := SendRequest{
-		EventID:   eventID,
-		Recipient: recipientID,
-		Profile:   profile,
-		Data:      data,
-	}
-
-	var response SendResponse
-	err := c.http.SendRequestWithJSON(ctx, "POST", "/send", payload, &response)
+// Send calls the /send endpoint of the Courier API (passing a struct)
+func (c *Client) Send(ctx context.Context, eventID, recipientID string, body interface{}) (string, error) {
+	bodyMap, err := toJSONMap(body)
 	if err != nil {
 		return "", err
 	}
-	return response.MessageID, nil
+
+	// these are required, so we accept them as separate params
+	bodyMap["event"] = eventID
+	bodyMap["recipient"] = recipientID
+
+	return c.SendMap(ctx, eventID, recipientID, bodyMap)
 }
 
-// func (c *Client) SendMap(ctx context.Context, eventID, recipientID string, porfile map[string]interface{}, data interface{}) (string, error) {
-// }
+// SendMap calls the /send endpoint of the Courier API (passing maps)
+func (c *Client) SendMap(ctx context.Context, eventID, recipientID string, body map[string]interface{}) (string, error) {
+	body["event"] = eventID
+	body["recipient"] = recipientID
+
+	response, err := c.http.SendRequestWithMaps(ctx, "POST", "/send", body)
+	if err != nil {
+		return "", err
+	}
+
+	var messageID string
+	err = json.Unmarshal(response["messageId"], &messageID)
+	if err != nil {
+		return "", err
+	}
+	return messageID, nil
+}

--- a/send.go
+++ b/send.go
@@ -4,17 +4,17 @@ import (
 	"context"
 )
 
-// SendResponse is the response returned by the CourierAPI upon success
-type SendResponse struct {
-	MessageID string `json:"messageId"`
-}
-
 // SendRequest is the JSON body expected by Courier's /send endpoint
 type SendRequest struct {
 	EventID   string      `json:"event"`
 	Recipient string      `json:"recipient"`
 	Profile   interface{} `json:"profile"`
 	Data      interface{} `json:"data"`
+}
+
+// SendResponse is the response returned by the CourierAPI upon success
+type SendResponse struct {
+	MessageID string `json:"messageId"`
 }
 
 // Send calls the /send endpoint of the Courier API
@@ -27,11 +27,10 @@ func (c *Client) Send(ctx context.Context, eventID, recipientID string, profile,
 	}
 
 	var response SendResponse
-	err := c.HTTPSendJSON(ctx, "POST", "/send", payload, &response)
+	err := c.http.SendRequestWithJSON(ctx, "POST", "/send", payload, &response)
 	if err != nil {
 		return "", err
 	}
-
 	return response.MessageID, nil
 }
 

--- a/send.go
+++ b/send.go
@@ -17,20 +17,16 @@ func (c *Client) Send(ctx context.Context, eventID, recipientID string, body int
 	if err != nil {
 		return "", err
 	}
-
-	// these are required, so we accept them as separate params
-	bodyMap["event"] = eventID
-	bodyMap["recipient"] = recipientID
-
 	return c.SendMap(ctx, eventID, recipientID, bodyMap)
 }
 
 // SendMap calls the /send endpoint of the Courier API (passing maps)
 func (c *Client) SendMap(ctx context.Context, eventID, recipientID string, body map[string]interface{}) (string, error) {
+	// these are required, so we accept them as separate params
 	body["event"] = eventID
 	body["recipient"] = recipientID
 
-	response, err := c.http.SendRequestWithMaps(ctx, "POST", "/send", body)
+	response, err := c.API.SendRequestWithMaps(ctx, "POST", "/send", body)
 	if err != nil {
 		return "", err
 	}

--- a/send_test.go
+++ b/send_test.go
@@ -1,9 +1,11 @@
 package courier_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -34,8 +36,13 @@ func TestSendMap(t *testing.T) {
 		func(rw http.ResponseWriter, req *http.Request) {
 			assert.Equal(t, url, req.URL.String())
 
-			decoder := json.NewDecoder(req.Body)
-			err := decoder.Decode(&requestBody)
+			buf := new(bytes.Buffer)
+			buf.ReadFrom(req.Body)
+			bodyJSON := buf.String()
+			log.Println("send_test.go: TestSendMap")
+			log.Println(bodyJSON)
+
+			err := json.Unmarshal(buf.Bytes(), &requestBody)
 			if err != nil {
 				t.Error(err)
 			}
@@ -53,21 +60,18 @@ func TestSendMap(t *testing.T) {
 		eventID := "event-id"
 		recipientID := "recipient-id"
 
-		var profile map[string]interface{}
-		profile = make(map[string]interface{})
+		profile := make(map[string]interface{})
 		profile["email"] = "foo@bar.com"
 
-		var data map[string]interface{}
-		data = make(map[string]interface{})
+		data := make(map[string]interface{})
 		data["foo"] = "bar"
 
-		var payload map[string]interface{}
-		payload = make(map[string]interface{})
-		payload["profile"] = profile
-		payload["data"] = data
+		body := make(map[string]interface{})
+		body["profile"] = profile
+		body["data"] = data
 
 		client := courier.CreateClient("key", &server.URL)
-		result, err := client.SendMap(context.Background(), eventID, recipientID, payload)
+		result, err := client.SendMap(context.Background(), eventID, recipientID, body)
 
 		assert.Nil(t, err)
 		assert.Equal(t, messageID, result)
@@ -100,8 +104,13 @@ func TestSendStruct(t *testing.T) {
 		func(rw http.ResponseWriter, req *http.Request) {
 			assert.Equal(t, url, req.URL.String())
 
-			decoder := json.NewDecoder(req.Body)
-			err := decoder.Decode(&requestBody)
+			buf := new(bytes.Buffer)
+			buf.ReadFrom(req.Body)
+			bodyJSON := buf.String()
+			log.Println("send_test.go: TestSendStruct")
+			log.Println(bodyJSON)
+
+			err := json.Unmarshal(buf.Bytes(), &requestBody)
 			if err != nil {
 				t.Error(err)
 			}

--- a/send_test.go
+++ b/send_test.go
@@ -8,13 +8,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/trycourier/courier-go"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/trycourier/courier-go"
 )
 
-func TestSend(t *testing.T) {
-
+func TestSendMap(t *testing.T) {
 	type Data struct {
 		Foo string
 	}
@@ -29,13 +27,12 @@ func TestSend(t *testing.T) {
 	}
 
 	var requestBody RequestBody
+	url := "/send"
+	messageID := "123456789"
 
-	expectedResponseID := "123456789"
 	server := httptest.NewServer(http.HandlerFunc(
-
 		func(rw http.ResponseWriter, req *http.Request) {
-
-			assert.Equal(t, "/send", req.URL.String())
+			assert.Equal(t, url, req.URL.String())
 
 			decoder := json.NewDecoder(req.Body)
 			err := decoder.Decode(&requestBody)
@@ -44,34 +41,106 @@ func TestSend(t *testing.T) {
 			}
 
 			rw.Header().Add("Content-Type", "application/json")
-			_, writeErr := rw.Write([]byte(fmt.Sprintf("{ \"messageId\" : \"%s\" }", expectedResponseID)))
+			_, writeErr := rw.Write([]byte(fmt.Sprintf("{ \"messageId\" : \"%s\" }", messageID)))
 			if writeErr != nil {
 				t.Error(writeErr)
 			}
-
-		}))
+		}),
+	)
 	defer server.Close()
 
 	t.Run("sends request", func(t *testing.T) {
+		eventID := "event-id"
+		recipientID := "recipient-id"
+
+		var profile map[string]interface{}
+		profile = make(map[string]interface{})
+		profile["email"] = "foo@bar.com"
+
+		var data map[string]interface{}
+		data = make(map[string]interface{})
+		data["foo"] = "bar"
+
+		var payload map[string]interface{}
+		payload = make(map[string]interface{})
+		payload["profile"] = profile
+		payload["data"] = data
 
 		client := courier.CreateClient("key", &server.URL)
-
-		data := &Data{
-			Foo: "bar",
-		}
-		profile := &Profile{
-			Email: "foo@bar.com",
-		}
-		eventID := "event-id"
-		recipientID := "recpient-id"
-		messageID, err := client.Send(context.Background(), eventID, recipientID, profile, data)
+		result, err := client.SendMap(context.Background(), eventID, recipientID, payload)
 
 		assert.Nil(t, err)
-		assert.Equal(t, expectedResponseID, messageID)
+		assert.Equal(t, messageID, result)
 		assert.Equal(t, eventID, requestBody.Event)
 		assert.Equal(t, recipientID, requestBody.Recipient)
-		assert.Equal(t, data.Foo, requestBody.Data.Foo)
-		assert.Equal(t, profile.Email, requestBody.Profile.Email)
+		assert.Equal(t, "foo@bar.com", requestBody.Profile.Email)
+		assert.Equal(t, "bar", requestBody.Data.Foo)
 	})
+}
 
+func TestSendStruct(t *testing.T) {
+	type RequestData struct {
+		Foo string
+	}
+	type RequestProfile struct {
+		Email string
+	}
+	type RequestBody struct {
+		Event     string
+		Recipient string
+		Profile   RequestProfile
+		Data      RequestData
+	}
+
+	var requestBody RequestBody
+	url := "/send"
+	messageID := "123456789"
+
+	server := httptest.NewServer(http.HandlerFunc(
+		func(rw http.ResponseWriter, req *http.Request) {
+			assert.Equal(t, url, req.URL.String())
+
+			decoder := json.NewDecoder(req.Body)
+			err := decoder.Decode(&requestBody)
+			if err != nil {
+				t.Error(err)
+			}
+
+			rw.Header().Add("Content-Type", "application/json")
+			_, writeErr := rw.Write([]byte(fmt.Sprintf("{ \"messageId\" : \"%s\" }", messageID)))
+			if writeErr != nil {
+				t.Error(writeErr)
+			}
+		}),
+	)
+	defer server.Close()
+
+	t.Run("sends request", func(t *testing.T) {
+		type data struct {
+			Foo string `json:"foo"`
+		}
+		type profile struct {
+			Email string `json:"email"`
+		}
+
+		eventID := "event-id"
+		recipientID := "recipient-id"
+
+		client := courier.CreateClient("key", &server.URL)
+		result, err := client.Send(context.Background(), eventID, recipientID, courier.SendBody{
+			profile{
+				Email: "foo@bar.com",
+			},
+			data{
+				Foo: "bar",
+			},
+		})
+
+		assert.Nil(t, err)
+		assert.Equal(t, messageID, result)
+		assert.Equal(t, eventID, requestBody.Event)
+		assert.Equal(t, recipientID, requestBody.Recipient)
+		assert.Equal(t, "foo@bar.com", requestBody.Profile.Email)
+		assert.Equal(t, "bar", requestBody.Data.Foo)
+	})
 }

--- a/send_test.go
+++ b/send_test.go
@@ -44,7 +44,7 @@ func TestSend(t *testing.T) {
 			}
 
 			rw.Header().Add("Content-Type", "application/json")
-			_, writeErr := rw.Write([]byte(fmt.Sprintf("{ \"MessageId\" : \"%s\" }", expectedResponseID)))
+			_, writeErr := rw.Write([]byte(fmt.Sprintf("{ \"messageId\" : \"%s\" }", expectedResponseID)))
 			if writeErr != nil {
 				t.Error(writeErr)
 			}
@@ -54,7 +54,7 @@ func TestSend(t *testing.T) {
 
 	t.Run("sends request", func(t *testing.T) {
 
-		client := courier.CourierClient("key", server.URL)
+		client := courier.CreateClient("key", &server.URL)
 
 		data := &Data{
 			Foo: "bar",


### PR DESCRIPTION
Major changes:

* `courier.CourierClient` has been renamed to `courier.CreateClient`
* `courier.CreateClient` now takes a `nil` second parameter if you wish to use our default API URL, not `""`
* Our underlying API communication functionas are now exposed via `client.API`
* renamed `SendRequest` to `SendBody` and modified the struct
* `Send` now takes one `body interface{}` argument rather than separate `profile` and `data` arguments
* added `SendMap`
* `GetProfile` now requires a `context` argument 
* `GetProfile` now returns a `map[string]json.RawMessage{}` instead of hydrating a struct reference
* removed `MergeProfile`; use `client.API.SendRequestWithBytes(context.Background(), "PUT", "/profiles/"+recipientID, profile)` instead
* removed `UpdateProfile`; use `client.API.SendRequestWithBytes(context.Background(), "PUT", "/profiles/"+recipientID, profile)` instead