### PR TITLE
Set body to nil for GET requests

### DIFF
--- a/v2/api.go
+++ b/v2/api.go
@@ -80,6 +80,9 @@ func (api *APIConfiguration) SendRequestWithBytes(ctx context.Context, method st
 // SendRequestWithReader wraps HTTPRequest
 func (api *APIConfiguration) SendRequestWithReader(ctx context.Context, method string, relativePath string, body io.Reader) ([]byte, error) {
 	fullyQualifiedURL := api.BaseURL + relativePath
+	if method == "GET" {
+		body = nil
+	}
 	req, err := http.NewRequestWithContext(ctx, method, fullyQualifiedURL, body)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description of the change

A non nil body was being passed for GET requests. Check for method of GET and set the body to nil

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
