### PR TITLE
Add brand and override support to Send API

### DIFF
--- a/v2/send.go
+++ b/v2/send.go
@@ -7,8 +7,10 @@ import (
 
 // SendBody is the JSON body expected by Courier's /send endpoint
 type SendBody struct {
-	Profile interface{} `json:"profile"`
-	Data    interface{} `json:"data"`
+	Profile  interface{} `json:"profile"`
+	Data     interface{} `json:"data"`
+	Override interface{} `json:"override,omitempty"`
+	Brand    string      `json:"brand,omitempty"`
 }
 
 // Send calls the /send endpoint of the Courier API (passing a struct)


### PR DESCRIPTION
## Description of the change

> Adds brand and override to the SendBody

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
