### PR TITLE
Add webhook payload type

### DIFF
--- a/v2/webhooks.go
+++ b/v2/webhooks.go
@@ -1,0 +1,7 @@
+package courier
+
+// WebhookResponse represents the payload provided by an outbound webhook
+type WebhookResponse struct {
+	Data *MessageResponse `json:"data"`
+	Type string           `json:"type"`
+}


### PR DESCRIPTION
## Description of the change

> I noticed there was no existing type to represent the outbound webhook payload. I didn't see a great place to put it, so I created a new file.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> n/a

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
