### PR TITLE
Use http.DefaultClient to send API requests

### DIFF
--- a/v2/api.go
+++ b/v2/api.go
@@ -95,8 +95,7 @@ func (api *APIConfiguration) ExecuteRequest(req *http.Request) ([]byte, error) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "courier-go/"+api.SDKVersion)
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/api_test.go
+++ b/v2/api_test.go
@@ -1,0 +1,39 @@
+package courier
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCourier_ExecuteRequest(t *testing.T) {
+	t.Parallel()
+	want := []byte("Ok")
+	server := mockServer(want)
+	defer server.Close()
+	api := &APIConfiguration{
+		AuthToken: "",
+	}
+	req, err := http.NewRequestWithContext(context.Background(), "GET", server.URL, http.NoBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := api.ExecuteRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cmp.Equal(want, got) {
+		t.Error(cmp.Diff(string(want), string(got)))
+	}
+}
+
+func mockServer(want []byte) *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(want)
+	}))
+	return server
+}


### PR DESCRIPTION
http.DefaultClient uses a transport that tries to re-use network connections and this reduces the chances of port exhaustion.

[Multiple API Calls Open Multiple Network Connections](https://github.com/trycourier/courier-go/issues/52)

## Description of the change

> Description here

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
