### PR TITLE
Add cancel message endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Editor directories
+.idea/
+.vscode/

--- a/v2/messages.go
+++ b/v2/messages.go
@@ -2,6 +2,7 @@ package courier
 
 import (
 	"context"
+	"fmt"
 )
 
 // ProvidersChannelResponse represents the channel section of the ProvidersResponse
@@ -25,24 +26,40 @@ type ProvidersResponse struct {
 
 // MessageResponse represents the return of the /messages/* endpoints on the Courier API
 type MessageResponse struct {
-	ID           string
-	Event        string
-	Notification string
-	Status       string
-	Error        string
-	Reason       string
-	Recipient    string
-	Enqueued     int64
-	Delivered    int64
-	Sent         int64
-	Clicked      int64
-	Providers    []*ProvidersResponse
+	ID            string
+	Event         string
+	Notification  string
+	Status        string
+	Error         string
+	Reason        string
+	Recipient     string
+	JobId         string
+	ListId        string
+	ListMessageId string
+	RunId         string
+	Enqueued      int64
+	Delivered     int64
+	Sent          int64
+	Clicked       int64
+	Opened        int64
+	CanceledAt    int64
+	Providers     []*ProvidersResponse
 }
 
 // GetMessage calls the /messages/:id endpoint of the Courier API
 func (c *Client) GetMessage(ctx context.Context, messageID string) (*MessageResponse, error) {
 	var response MessageResponse
 	err := c.API.SendRequestWithJSON(ctx, "GET", "/messages/"+messageID, nil, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// CancelMessage calls the /messages/:id/cancel endpoint of the Courier API
+func (c *Client) CancelMessage(ctx context.Context, messageID string) (*MessageResponse, error) {
+	var response MessageResponse
+	err := c.API.SendRequestWithJSON(ctx, "POST", fmt.Sprintf("/messages/%s/cancel", messageID), nil, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/messages_test.go
+++ b/v2/messages_test.go
@@ -2,6 +2,7 @@ package courier_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -15,49 +16,28 @@ func TestMessages_GetMessage(t *testing.T) {
 	requestMessageID := "1-23456789"
 	status := "CLICKED"
 	sent := int64(1589563865697)
-	url := "/messages/" + requestMessageID
+	var expectedURL string
+	var rsp courier.MessageResponse
 
 	server := httptest.NewServer(http.HandlerFunc(
 		func(rw http.ResponseWriter, req *http.Request) {
-			assert.Equal(t, url, req.URL.String())
+			assert.Equal(t, expectedURL, req.URL.String())
 
 			rw.WriteHeader(http.StatusOK)
 			rw.Header().Add("Content-Type", "application/json")
-			rsp := `
-				{
-					"id": "%s",
-					"clicked": 1589563890843,
-					"delivered": 1589563972000,
-					"enqueued": 1589563863773,
-					"event": "GEFGNB2GNQ4MZVHW4WV4R8Q8ZVN5",
-					"notification": "GEFGNB2GNQ4MZVHW4WV4R8Q8ZVN5",
-					"providers": [
-						{
-							"channel": {
-								"key": "sendgrid",
-								"template": "5e95b992-3505-4f66-8808-f91d5d0fe8c9"
-							},
-							"clicked": 1589563890843,
-							"delivered": 1589563972000,
-							"provider": "sendgrid",
-							"reference": {
-								"message_id": "Xx14o44jToS8StSTPLGsTw.filterdrecv-p3iad2-8ddf98858-7qsdm-19-5EBED1D9-D3.0",
-								"x-message-id": "Xx14o44jToS8StSTPLGsTw"
-							},
-							"sent": 1589563865697,
-							"status": "DELIVERED"
-						}
-					],
-					"recipient": "tony@trycourier.com",
-					"sent": %d,
-					"status": "%s"
-				}`
-			_, _ = rw.Write([]byte(fmt.Sprintf(rsp, requestMessageID, sent, status)))
+			bytes, err := json.Marshal(rsp)
+			assert.Nil(t, err)
+			_, _ = rw.Write(bytes)
 		}),
 	)
 	defer server.Close()
 
 	t.Run("makes requests for message ID", func(t *testing.T) {
+		rsp = createResponse(requestMessageID, sent, status)
+		defer func() { rsp = courier.MessageResponse{} }() // reset response between tests
+
+		expectedURL = "/messages/" + requestMessageID
+
 		client := courier.CreateClient("key", &server.URL)
 		response, err := client.GetMessage(context.Background(), requestMessageID)
 		assert.Nil(t, err)
@@ -66,4 +46,54 @@ func TestMessages_GetMessage(t *testing.T) {
 		assert.Equal(t, sent, response.Sent)
 		assert.Equal(t, status, response.Status)
 	})
+
+	t.Run("makes requests to cancel a message", func(t *testing.T) {
+		rsp = createResponse(requestMessageID, sent, status)
+		defer func() { rsp = courier.MessageResponse{} }() // reset response between tests
+
+		canceledAt := int64(4567890)
+		rsp.CanceledAt = canceledAt
+
+		expectedURL = fmt.Sprintf("/messages/%s/cancel", requestMessageID)
+
+		client := courier.CreateClient("key", &server.URL)
+		response, err := client.CancelMessage(context.Background(), requestMessageID)
+		assert.Nil(t, err)
+
+		assert.Equal(t, requestMessageID, response.ID)
+		assert.Equal(t, sent, response.Sent)
+		assert.Equal(t, status, response.Status)
+		assert.Equal(t, canceledAt, response.CanceledAt)
+	})
+}
+
+func createResponse(requestMessageID string, sent int64, status string) courier.MessageResponse {
+	return courier.MessageResponse{
+		ID:           requestMessageID,
+		Clicked:      1589563890843,
+		Delivered:    1589563972000,
+		Enqueued:     1589563863773,
+		Event:        "GEFGNB2GNQ4MZVHW4WV4R8Q8ZVN5",
+		Notification: "GEFGNB2GNQ4MZVHW4WV4R8Q8ZVN5",
+		Providers: []*courier.ProvidersResponse{
+			{
+				Channel: &courier.ProvidersChannelResponse{
+					Key:      "sendgrid",
+					Template: "5e95b992-3505-4f66-8808-f91d5d0fe8c9",
+				},
+				Clicked:   1589563890843,
+				Delivered: 1589563972000,
+				Provider:  "sendgrid",
+				Reference: map[string]string{
+					"message_id":   "Xx14o44jToS8StSTPLGsTw.filterdrecv-p3iad2-8ddf98858-7qsdm-19-5EBED1D9-D3.0",
+					"x-message-id": "Xx14o44jToS8StSTPLGsTw",
+				},
+				Sent:   1589563865697,
+				Status: "DELIVERED",
+			},
+		},
+		Recipient: "tony@trycourier.com",
+		Sent:      sent,
+		Status:    status,
+	}
 }


### PR DESCRIPTION
## Description of the change

This adds support for the cancel message endpoint - https://www.courier.com/docs/reference/logs/cancel/ 

I also added in some missing fields to the MessageResponse struct and reworked the tests to better handle testing multiple endpoints

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
