### PR TITLE
docs: sync README from api-spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
-<!-- AUTO-GENERATED-OVERVIEW:START — Do not edit this section. It is synced from mintlify-docs. -->
 # Courier Go SDK
 
-The Courier Go SDK provides typed access to the Courier REST API from applications written in Go. It uses strongly typed request structs, automatic retries, and returns parsed response types.
+The Courier Go SDK provides typed access to the Courier REST API from Go applications. Use it to send notifications, manage user profiles, check message status, issue JWT tokens for client-side SDKs, and more.
 
 ## Installation
+
+```bash
+go get github.com/trycourier/courier-go/v4
+```
+
+Then import it:
 
 ```go
 import (
@@ -31,6 +36,7 @@ func main() {
 	client := courier.NewClient(
 		option.WithAPIKey("My API Key"), // defaults to os.LookupEnv("COURIER_API_KEY")
 	)
+
 	response, err := client.Send.Message(context.TODO(), courier.SendMessageParams{
 		Message: courier.SendMessageParamsMessage{
 			To: courier.SendMessageParamsMessageToUnion{
@@ -39,13 +45,13 @@ func main() {
 				},
 			},
 			Template: courier.String("your_template_id"),
-			Data: map[string]any{"foo": "bar"},
 		},
 	})
 	if err != nil {
-		panic(err.Error())
+		panic(err)
 	}
-	fmt.Printf("%+v\n", response.RequestID)
+
+	fmt.Println(response.RequestID)
 }
 ```
 
@@ -58,4 +64,3 @@ Full documentation: **[courier.com/docs/sdk-libraries/go](https://www.courier.co
 - [Quickstart](https://www.courier.com/docs/getting-started/quickstart/)
 - [Send API](https://www.courier.com/docs/platform/sending/send-message/)
 - [API Reference](https://www.courier.com/docs/reference/get-started/)
-<!-- AUTO-GENERATED-OVERVIEW:END -->


### PR DESCRIPTION
Takes ownership of this README in the SDK repo.

`trycourier/api-spec` used to overwrite it on every spec merge, from its own `READMEs/<target>.md` overlay. That overlay is being removed (trycourier/api-spec#200) — kits are now generated SDK source only, and `README.md` is pruned from them. This lands the api-spec copy here once so nothing is lost, and from now on **this repo owns its README**.

Two notes:

- The `AUTO-GENERATED-OVERVIEW` markers are dropped. They claimed the file was synced from mintlify-docs, but `mintlify-docs/sdk-libraries/readme-exports/readme-sync-map.json` targets only the web and mobile SDKs — never this repo. Nothing has been rewriting them, and the banner told maintainers not to edit a file they in fact own.
- Where the install snippet carries a version, it is wrapped in `x-release-please-start-version` markers so release-please keeps it current on each release (this repo already lists `README.md` in its `extra-files`).

Review the content as a normal docs change — if the previous version read better in places, keep those parts.