### PR TITLE
docs(api): give every request body an example, and correct the archive status code

### DIFF
--- a/audience_test.go
+++ b/audience_test.go
@@ -54,17 +54,17 @@ func TestAudienceUpdateWithOptionalParams(t *testing.T) {
 		context.TODO(),
 		"audience_id",
 		courier.AudienceUpdateParams{
-			Description: courier.String("description"),
+			Description: courier.String("Users located in the US"),
 			Filter: shared.AudienceFilterConfigParam{
 				Filters: []shared.FilterConfigParam{{
-					Operator: "operator",
+					Operator: "EQ",
 					Filters:  []shared.FilterConfigParam{},
-					Path:     courier.String("path"),
-					Value:    courier.String("value"),
+					Path:     courier.String("profile.location"),
+					Value:    courier.String("US"),
 				}},
 				Operator: shared.AudienceFilterConfigOperatorAnd,
 			},
-			Name:     courier.String("name"),
+			Name:     courier.String("Engaged US Users"),
 			Operator: courier.AudienceUpdateParamsOperatorAnd,
 		},
 	)

--- a/automationinvoke_test.go
+++ b/automationinvoke_test.go
@@ -88,13 +88,13 @@ func TestAutomationInvokeInvokeByTemplateWithOptionalParams(t *testing.T) {
 		context.TODO(),
 		"templateId",
 		courier.AutomationInvokeInvokeByTemplateParams{
-			Recipient: courier.String("recipient"),
+			Recipient: courier.String("user_abc"),
 			Brand:     courier.String("brand"),
 			Data: map[string]any{
-				"foo": "bar",
+				"orderId": "bar",
 			},
 			Profile: map[string]any{
-				"foo": "bar",
+				"email": "bar",
 			},
 			Template:               courier.String("template"),
 			IdempotencyKey:         courier.String("order-ORD-456-user-123"),

--- a/brand_test.go
+++ b/brand_test.go
@@ -151,11 +151,11 @@ func TestBrandUpdateWithOptionalParams(t *testing.T) {
 		context.TODO(),
 		"brand_id",
 		courier.BrandUpdateParams{
-			Name: "name",
+			Name: "My Brand",
 			Settings: courier.BrandSettingsParam{
 				Colors: courier.BrandColorsParam{
-					Primary:   courier.String("primary"),
-					Secondary: courier.String("secondary"),
+					Primary:   courier.String("#9D3789"),
+					Secondary: courier.String("#FFFFFF"),
 				},
 				Email: courier.BrandSettingsEmailParam{
 					Footer: courier.EmailFooterParam{

--- a/bulk_test.go
+++ b/bulk_test.go
@@ -32,7 +32,9 @@ func TestBulkAddUsers(t *testing.T) {
 		"job_id",
 		courier.BulkAddUsersParams{
 			Users: []courier.InboundBulkMessageUserParam{{
-				Data: map[string]any{},
+				Data: map[string]any{
+					"name": "Jane",
+				},
 				Preferences: shared.RecipientPreferencesParam{
 					Categories: map[string]shared.NotificationPreferenceDetailsParam{
 						"foo": {
@@ -60,9 +62,9 @@ func TestBulkAddUsers(t *testing.T) {
 					},
 				},
 				Profile: map[string]any{
-					"foo": "bar",
+					"email": "bar",
 				},
-				Recipient: courier.String("recipient"),
+				Recipient: courier.String("user_abc"),
 				To: shared.UserRecipientParam{
 					AccountID: courier.String("account_id"),
 					Context: shared.MessageContextParam{
@@ -134,8 +136,8 @@ func TestBulkNewJobWithOptionalParams(t *testing.T) {
 	)
 	_, err := client.Bulk.NewJob(context.TODO(), courier.BulkNewJobParams{
 		Message: courier.InboundBulkMessageParam{
-			Event: "event",
-			Brand: courier.String("brand"),
+			Event: "welcome-series",
+			Brand: courier.String("bnd_01kx4mrd0pfzw8wt7pn7p2fzag"),
 			Content: courier.InboundBulkMessageContentUnionParam{
 				OfElementalContentSugar: &shared.ElementalContentSugarParam{
 					Body:  "body",
@@ -143,7 +145,7 @@ func TestBulkNewJobWithOptionalParams(t *testing.T) {
 				},
 			},
 			Data: map[string]any{
-				"foo": "bar",
+				"campaign": "bar",
 			},
 			Locale: map[string]map[string]any{
 				"foo": {

--- a/list_test.go
+++ b/list_test.go
@@ -54,7 +54,7 @@ func TestListUpdateWithOptionalParams(t *testing.T) {
 		context.TODO(),
 		"list_id",
 		courier.ListUpdateParams{
-			Name: "name",
+			Name: "Product Updates",
 			Preferences: shared.RecipientPreferencesParam{
 				Categories: map[string]shared.NotificationPreferenceDetailsParam{
 					"foo": {

--- a/listsubscription_test.go
+++ b/listsubscription_test.go
@@ -61,7 +61,35 @@ func TestListSubscriptionAddWithOptionalParams(t *testing.T) {
 		"list_id",
 		courier.ListSubscriptionAddParams{
 			Recipients: []courier.PutSubscriptionsRecipientParam{{
-				RecipientID: "recipientId",
+				RecipientID: "user_abc",
+				Preferences: shared.RecipientPreferencesParam{
+					Categories: map[string]shared.NotificationPreferenceDetailsParam{
+						"foo": {
+							Status: shared.PreferenceStatusOptedIn,
+							ChannelPreferences: []shared.ChannelPreferenceParam{{
+								Channel: shared.ChannelClassificationDirectMessage,
+							}},
+							Rules: []shared.RuleParam{{
+								Until: "until",
+								Start: courier.String("start"),
+							}},
+						},
+					},
+					Notifications: map[string]shared.NotificationPreferenceDetailsParam{
+						"foo": {
+							Status: shared.PreferenceStatusOptedIn,
+							ChannelPreferences: []shared.ChannelPreferenceParam{{
+								Channel: shared.ChannelClassificationDirectMessage,
+							}},
+							Rules: []shared.RuleParam{{
+								Until: "until",
+								Start: courier.String("start"),
+							}},
+						},
+					},
+				},
+			}, {
+				RecipientID: "user_def",
 				Preferences: shared.RecipientPreferencesParam{
 					Categories: map[string]shared.NotificationPreferenceDetailsParam{
 						"foo": {
@@ -120,7 +148,35 @@ func TestListSubscriptionSubscribe(t *testing.T) {
 		"list_id",
 		courier.ListSubscriptionSubscribeParams{
 			Recipients: []courier.PutSubscriptionsRecipientParam{{
-				RecipientID: "recipientId",
+				RecipientID: "user_abc",
+				Preferences: shared.RecipientPreferencesParam{
+					Categories: map[string]shared.NotificationPreferenceDetailsParam{
+						"foo": {
+							Status: shared.PreferenceStatusOptedIn,
+							ChannelPreferences: []shared.ChannelPreferenceParam{{
+								Channel: shared.ChannelClassificationDirectMessage,
+							}},
+							Rules: []shared.RuleParam{{
+								Until: "until",
+								Start: courier.String("start"),
+							}},
+						},
+					},
+					Notifications: map[string]shared.NotificationPreferenceDetailsParam{
+						"foo": {
+							Status: shared.PreferenceStatusOptedIn,
+							ChannelPreferences: []shared.ChannelPreferenceParam{{
+								Channel: shared.ChannelClassificationDirectMessage,
+							}},
+							Rules: []shared.RuleParam{{
+								Until: "until",
+								Start: courier.String("start"),
+							}},
+						},
+					},
+				},
+			}, {
+				RecipientID: "user_def",
 				Preferences: shared.RecipientPreferencesParam{
 					Categories: map[string]shared.NotificationPreferenceDetailsParam{
 						"foo": {
@@ -191,7 +247,7 @@ func TestListSubscriptionSubscribeUserWithOptionalParams(t *testing.T) {
 					},
 				},
 				Notifications: map[string]shared.NotificationPreferenceDetailsParam{
-					"foo": {
+					"nt_01kx4h2jdafq8bk9aftxak4b40": {
 						Status: shared.PreferenceStatusOptedIn,
 						ChannelPreferences: []shared.ChannelPreferenceParam{{
 							Channel: shared.ChannelClassificationDirectMessage,

--- a/notificationcheck_test.go
+++ b/notificationcheck_test.go
@@ -32,7 +32,7 @@ func TestNotificationCheckUpdate(t *testing.T) {
 		courier.NotificationCheckUpdateParams{
 			ID: "id",
 			Checks: []courier.BaseCheckParam{{
-				ID:     "id",
+				ID:     "abc-123",
 				Status: courier.BaseCheckStatusResolved,
 				Type:   courier.BaseCheckTypeCustom,
 			}},

--- a/profile_test.go
+++ b/profile_test.go
@@ -31,7 +31,8 @@ func TestProfileNewWithOptionalParams(t *testing.T) {
 		"user_id",
 		courier.ProfileNewParams{
 			Profile: map[string]any{
-				"foo": "bar",
+				"email":        "bar",
+				"phone_number": "bar",
 			},
 			IdempotencyKey:         courier.String("order-ORD-456-user-123"),
 			XIdempotencyExpiration: courier.String("1785312000"),
@@ -87,9 +88,9 @@ func TestProfileUpdate(t *testing.T) {
 		"user_id",
 		courier.ProfileUpdateParams{
 			Patch: []courier.ProfileUpdateParamsPatch{{
-				Op:    "op",
-				Path:  "path",
-				Value: "value",
+				Op:    "replace",
+				Path:  "/email",
+				Value: "jdoe@example.com",
 			}},
 		},
 	)
@@ -143,7 +144,9 @@ func TestProfileReplace(t *testing.T) {
 		"user_id",
 		courier.ProfileReplaceParams{
 			Profile: map[string]any{
-				"foo": "bar",
+				"email":        "bar",
+				"phone_number": "bar",
+				"locale":       "bar",
 			},
 		},
 	)

--- a/profilelist_test.go
+++ b/profilelist_test.go
@@ -84,7 +84,7 @@ func TestProfileListSubscribeWithOptionalParams(t *testing.T) {
 		"user_id",
 		courier.ProfileListSubscribeParams{
 			Lists: []courier.SubscribeToListsRequestItemParam{{
-				ListID: "listId",
+				ListID: "example.list.id",
 				Preferences: shared.RecipientPreferencesParam{
 					Categories: map[string]shared.NotificationPreferenceDetailsParam{
 						"foo": {

--- a/provider_test.go
+++ b/provider_test.go
@@ -27,12 +27,12 @@ func TestProviderNewWithOptionalParams(t *testing.T) {
 		option.WithAPIKey("My API Key"),
 	)
 	_, err := client.Providers.New(context.TODO(), courier.ProviderNewParams{
-		Provider: "provider",
+		Provider: "sendgrid",
 		Alias:    courier.String("alias"),
 		Settings: map[string]any{
-			"foo": "bar",
+			"api_key": "bar",
 		},
-		Title:                  courier.String("title"),
+		Title:                  courier.String("Production SendGrid"),
 		IdempotencyKey:         courier.String("order-ORD-456-user-123"),
 		XIdempotencyExpiration: courier.String("1785312000"),
 	})
@@ -85,12 +85,12 @@ func TestProviderUpdateWithOptionalParams(t *testing.T) {
 		context.TODO(),
 		"id",
 		courier.ProviderUpdateParams{
-			Provider: "provider",
+			Provider: "sendgrid",
 			Alias:    courier.String("alias"),
 			Settings: map[string]any{
-				"foo": "bar",
+				"api_key": "bar",
 			},
-			Title: courier.String("title"),
+			Title: courier.String("Production SendGrid"),
 		},
 	)
 	if err != nil {

--- a/tenant_test.go
+++ b/tenant_test.go
@@ -54,8 +54,8 @@ func TestTenantUpdateWithOptionalParams(t *testing.T) {
 		context.TODO(),
 		"tenant_id",
 		courier.TenantUpdateParams{
-			Name:    "name",
-			BrandID: courier.String("brand_id"),
+			Name:    "Acme Corp",
+			BrandID: courier.String("bnd_01kx4mrd0pfzw8wt7pn7p2fzag"),
 			DefaultPreferences: courier.DefaultPreferencesParam{
 				Items: []courier.DefaultPreferencesItemParam{{
 					SubscriptionTopicNewParam: courier.SubscriptionTopicNewParam{
@@ -68,7 +68,7 @@ func TestTenantUpdateWithOptionalParams(t *testing.T) {
 			},
 			ParentTenantID: courier.String("parent_tenant_id"),
 			Properties: map[string]any{
-				"foo": "bar",
+				"plan": "bar",
 			},
 			UserProfile: map[string]any{
 				"foo": "bar",

--- a/tenanttemplate_test.go
+++ b/tenanttemplate_test.go
@@ -121,7 +121,7 @@ func TestTenantTemplatePublishWithOptionalParams(t *testing.T) {
 		courier.TenantTemplatePublishParams{
 			TenantID: "tenant_id",
 			PostTenantTemplatePublishRequest: courier.PostTenantTemplatePublishRequestParam{
-				Version: courier.String("version"),
+				Version: courier.String("latest"),
 			},
 		},
 	)
@@ -166,7 +166,7 @@ func TestTenantTemplateReplaceWithOptionalParams(t *testing.T) {
 								Type: "text",
 							},
 						}},
-						Version: "version",
+						Version: "2022-01-01",
 					},
 					Channels: shared.MessageChannelsParam{
 						"foo": shared.ChannelParam{
@@ -212,9 +212,9 @@ func TestTenantTemplateReplaceWithOptionalParams(t *testing.T) {
 					},
 					Routing: shared.MessageRoutingParam{
 						Channels: []shared.MessageRoutingChannelUnionParam{{
-							OfString: courier.String("string"),
+							OfString: courier.String("email"),
 						}},
-						Method: shared.MessageRoutingMethodAll,
+						Method: shared.MessageRoutingMethodSingle,
 					},
 				},
 				Published: courier.Bool(true),

--- a/translation_test.go
+++ b/translation_test.go
@@ -60,7 +60,7 @@ func TestTranslationUpdate(t *testing.T) {
 		"locale",
 		courier.TranslationUpdateParams{
 			Domain: "domain",
-			Body:   "body",
+			Body:   "msgid \"Hello\"\nmsgstr \"Hola\"",
 		},
 	)
 	if err != nil {

--- a/usertenant_test.go
+++ b/usertenant_test.go
@@ -61,7 +61,14 @@ func TestUserTenantAddMultiple(t *testing.T) {
 		"user_id",
 		courier.UserTenantAddMultipleParams{
 			Tenants: []courier.TenantAssociationParam{{
-				TenantID: "tenant_id",
+				TenantID: "tenant_abc",
+				Profile: map[string]any{
+					"foo": "bar",
+				},
+				Type:   courier.TenantAssociationTypeUser,
+				UserID: courier.String("user_id"),
+			}, {
+				TenantID: "tenant_def",
 				Profile: map[string]any{
 					"foo": "bar",
 				},
@@ -98,7 +105,7 @@ func TestUserTenantAddSingleWithOptionalParams(t *testing.T) {
 		courier.UserTenantAddSingleParams{
 			UserID: "user_id",
 			Profile: map[string]any{
-				"foo": "bar",
+				"role": "bar",
 			},
 		},
 	)

--- a/usertoken_test.go
+++ b/usertoken_test.go
@@ -61,9 +61,9 @@ func TestUserTokenUpdate(t *testing.T) {
 		courier.UserTokenUpdateParams{
 			UserID: "user_id",
 			Patch: []courier.UserTokenUpdateParamsPatch{{
-				Op:    "op",
-				Path:  "path",
-				Value: courier.String("value"),
+				Op:    "replace",
+				Path:  "/expiry_date",
+				Value: courier.String("2024-12-31T00:00:00.000Z"),
 			}},
 		},
 	)
@@ -172,7 +172,7 @@ func TestUserTokenAddSingleWithOptionalParams(t *testing.T) {
 			ProviderKey: courier.UserTokenAddSingleParamsProviderKeyFirebaseFcm,
 			Device: courier.UserTokenAddSingleParamsDevice{
 				AdID:         courier.String("ad_id"),
-				AppID:        courier.String("app_id"),
+				AppID:        courier.String("com.example.app"),
 				DeviceID:     courier.String("device_id"),
 				Manufacturer: courier.String("manufacturer"),
 				Model:        courier.String("model"),

--- a/workspacepreference_test.go
+++ b/workspacepreference_test.go
@@ -130,9 +130,9 @@ func TestWorkspacePreferencePublishWithOptionalParams(t *testing.T) {
 	)
 	_, err := client.WorkspacePreferences.Publish(context.TODO(), courier.WorkspacePreferencePublishParams{
 		PublishPreferencesRequest: courier.PublishPreferencesRequestParam{
-			BrandID:     courier.String("brand_id"),
-			Description: courier.String("description"),
-			Heading:     courier.String("heading"),
+			BrandID:     courier.String("bnd_01kx4mrd0pfzw8wt7pn7p2fzag"),
+			Description: courier.String("Choose what you hear from us about."),
+			Heading:     courier.String("Notification Preferences"),
 		},
 		IdempotencyKey:         courier.String("order-ORD-456-user-123"),
 		XIdempotencyExpiration: courier.String("1785312000"),
@@ -164,10 +164,10 @@ func TestWorkspacePreferenceReplaceWithOptionalParams(t *testing.T) {
 		"section_id",
 		courier.WorkspacePreferenceReplaceParams{
 			WorkspacePreferenceReplaceRequest: courier.WorkspacePreferenceReplaceRequestParam{
-				Name:             "name",
+				Name:             "Account Notifications",
 				Description:      courier.String("description"),
 				HasCustomRouting: courier.Bool(true),
-				RoutingOptions:   []shared.ChannelClassification{shared.ChannelClassificationDirectMessage},
+				RoutingOptions:   []shared.ChannelClassification{shared.ChannelClassificationEmail, shared.ChannelClassificationPush},
 			},
 		},
 	)

--- a/workspacepreferencetopic_test.go
+++ b/workspacepreferencetopic_test.go
@@ -155,12 +155,12 @@ func TestWorkspacePreferenceTopicReplaceWithOptionalParams(t *testing.T) {
 		courier.WorkspacePreferenceTopicReplaceParams{
 			SectionID: "section_id",
 			WorkspacePreferenceTopicReplaceRequest: courier.WorkspacePreferenceTopicReplaceRequestParam{
-				DefaultStatus:            courier.WorkspacePreferenceTopicReplaceRequestDefaultStatusOptedOut,
-				Name:                     "name",
-				AllowedPreferences:       []string{"snooze"},
+				DefaultStatus:            courier.WorkspacePreferenceTopicReplaceRequestDefaultStatusOptedIn,
+				Name:                     "Product Updates",
+				AllowedPreferences:       []string{"channel_preferences"},
 				Description:              courier.String("description"),
 				IncludeUnsubscribeHeader: courier.Bool(true),
-				RoutingOptions:           []shared.ChannelClassification{shared.ChannelClassificationDirectMessage},
+				RoutingOptions:           []shared.ChannelClassification{shared.ChannelClassificationEmail, shared.ChannelClassificationInbox},
 				TopicData: map[string]any{
 					"foo": "bar",
 				},


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

17 files changed, 125 insertions(+), 57 deletions(-)

<details><summary>Files</summary>

```
 audience_test.go                 | 10 +++++-----
 automationinvoke_test.go         |  6 +++---
 brand_test.go                    |  6 +++---
 bulk_test.go                     | 14 ++++++++------
 list_test.go                     |  2 +-
 listsubscription_test.go         | 62 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++---
 notificationcheck_test.go        |  2 +-
 profile_test.go                  | 13 ++++++++-----
 profilelist_test.go              |  2 +-
 provider_test.go                 | 12 ++++++------
 tenant_test.go                   |  6 +++---
 tenanttemplate_test.go           |  8 ++++----
 translation_test.go              |  2 +-
 usertenant_test.go               | 11 +++++++++--
 usertoken_test.go                |  8 ++++----
 workspacepreference_test.go      | 10 +++++-----
 workspacepreferencetopic_test.go |  8 ++++----
 17 files changed, 125 insertions(+), 57 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

Merging with a releasable Conventional Commit title (`feat`/`fix`/`perf`) lets release-please open a release PR; `chore`/`docs` land in the changelog without cutting a release.
