### PR TITLE
docs(api): say what the bulk job endpoints return

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -70,7 +70,8 @@ func (r *BulkService) NewJob(ctx context.Context, body BulkNewJobParams, opts ..
 	return res, err
 }
 
-// Get Bulk Job Users
+// Returns the users ingested into a bulk job with paging, each carrying the status
+// Courier recorded for it and the id of the message it produced.
 func (r *BulkService) ListUsers(ctx context.Context, jobID string, query BulkListUsersParams, opts ...option.RequestOption) (res *BulkListUsersResponse, err error) {
 	opts = slices.Concat(r.Options, opts)
 	if jobID == "" {
@@ -82,7 +83,9 @@ func (r *BulkService) ListUsers(ctx context.Context, jobID string, query BulkLis
 	return res, err
 }
 
-// Get a bulk job
+// Returns a bulk job's message definition, its status — CREATED, PROCESSING,
+// COMPLETED, or ERROR — and running counts of users received, messages enqueued,
+// and failures. Poll it to follow a job through to completion.
 func (r *BulkService) GetJob(ctx context.Context, jobID string, opts ...option.RequestOption) (res *BulkGetJobResponse, err error) {
 	opts = slices.Concat(r.Options, opts)
 	if jobID == "" {
@@ -94,7 +97,9 @@ func (r *BulkService) GetJob(ctx context.Context, jobID string, opts ...option.R
 	return res, err
 }
 
-// Run a bulk job
+// Starts processing a bulk job, sending to every user ingested into it. Returns
+// 204 immediately; the job runs asynchronously, so poll the job to watch its
+// status and counts.
 func (r *BulkService) RunJob(ctx context.Context, jobID string, opts ...option.RequestOption) (err error) {
 	opts = slices.Concat(r.Options, opts)
 	opts = append([]option.RequestOption{option.WithHeader("Accept", "*/*")}, opts...)


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

1 file changed, 8 insertions(+), 3 deletions(-)

<details><summary>Files</summary>

```
 bulk.go | 11 ++++++++---
 1 file changed, 8 insertions(+), 3 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
