### PR TITLE
feat(api): add automation and journey run log endpoints

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,1 +1,1 @@
-configured_endpoints: 149
+configured_endpoints: 154

--- a/api.md
+++ b/api.md
@@ -185,6 +185,10 @@ Methods:
 Response Types:
 
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#AutomationInvokeResponse">AutomationInvokeResponse</a>
+- <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#AutomationRunListItem">AutomationRunListItem</a>
+- <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#AutomationRunListResponse">AutomationRunListResponse</a>
+- <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#AutomationRunStep">AutomationRunStep</a>
+- <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#AutomationRunStepsResponse">AutomationRunStepsResponse</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#AutomationTemplate">AutomationTemplate</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#AutomationTemplateListResponse">AutomationTemplateListResponse</a>
 
@@ -199,6 +203,13 @@ Methods:
 - <code title="post /automations/invoke">client.Automations.Invoke.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#AutomationInvokeService.InvokeAdHoc">InvokeAdHoc</a>(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, params <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#AutomationInvokeInvokeAdHocParams">AutomationInvokeInvokeAdHocParams</a>) (\*<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#AutomationInvokeResponse">AutomationInvokeResponse</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code>
 - <code title="post /automations/{templateId}/invoke">client.Automations.Invoke.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#AutomationInvokeService.InvokeByTemplate">InvokeByTemplate</a>(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, templateID <a href="https://pkg.go.dev/builtin#string">string</a>, params <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#AutomationInvokeInvokeByTemplateParams">AutomationInvokeInvokeByTemplateParams</a>) (\*<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#AutomationInvokeResponse">AutomationInvokeResponse</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code>
 
+## Runs
+
+Methods:
+
+- <code title="get /automations/runs">client.Automations.Runs.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#AutomationRunService.List">List</a>(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, query <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#AutomationRunListParams">AutomationRunListParams</a>) (\*<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#AutomationRunListResponse">AutomationRunListResponse</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code>
+- <code title="get /automations/runs/{id}/steps">client.Automations.Runs.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#AutomationRunService.ListSteps">ListSteps</a>(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, id <a href="https://pkg.go.dev/builtin#string">string</a>) (\*<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#AutomationRunStepsResponse">AutomationRunStepsResponse</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code>
+
 # Journeys
 
 Params Types:
@@ -207,6 +218,7 @@ Params Types:
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#CreateJourneyRequestParam">CreateJourneyRequestParam</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyAINodeParam">JourneyAINodeParam</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyAPIInvokeTriggerNodeParam">JourneyAPIInvokeTriggerNodeParam</a>
+- <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyAudienceTriggerNodeParam">JourneyAudienceTriggerNodeParam</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyConditionAtom">JourneyConditionAtom</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyConditionGroupParam">JourneyConditionGroupParam</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyConditionNestedGroupParam">JourneyConditionNestedGroupParam</a>
@@ -229,6 +241,7 @@ Params Types:
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyTemplateReplaceRequestParam">JourneyTemplateReplaceRequestParam</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyThrottleDynamicNodeParam">JourneyThrottleDynamicNodeParam</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyThrottleStaticNodeParam">JourneyThrottleStaticNodeParam</a>
+- <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyWebhookTriggerNodeParam">JourneyWebhookTriggerNodeParam</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneysInvokeRequestParam">JourneysInvokeRequestParam</a>
 
 Response Types:
@@ -237,6 +250,7 @@ Response Types:
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#Journey">Journey</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyAINode">JourneyAINode</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyAPIInvokeTriggerNode">JourneyAPIInvokeTriggerNode</a>
+- <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyAudienceTriggerNode">JourneyAudienceTriggerNode</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyConditionAtom">JourneyConditionAtom</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyConditionGroup">JourneyConditionGroup</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyConditionNestedGroup">JourneyConditionNestedGroup</a>
@@ -251,6 +265,12 @@ Response Types:
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyMergeStrategy">JourneyMergeStrategy</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyNodeUnion">JourneyNodeUnion</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyResponse">JourneyResponse</a>
+- <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyRun">JourneyRun</a>
+- <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyRunListItem">JourneyRunListItem</a>
+- <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyRunListResponse">JourneyRunListResponse</a>
+- <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyRunResponse">JourneyRunResponse</a>
+- <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyRunStep">JourneyRunStep</a>
+- <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyRunStepsResponse">JourneyRunStepsResponse</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneySegmentTriggerNode">JourneySegmentTriggerNode</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneySendNode">JourneySendNode</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyState">JourneyState</a>
@@ -261,6 +281,7 @@ Response Types:
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyThrottleStaticNode">JourneyThrottleStaticNode</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyVersionItem">JourneyVersionItem</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyVersionsListResponse">JourneyVersionsListResponse</a>
+- <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyWebhookTriggerNode">JourneyWebhookTriggerNode</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneysInvokeResponse">JourneysInvokeResponse</a>
 - <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneysListResponse">JourneysListResponse</a>
 
@@ -290,6 +311,14 @@ Methods:
 - <code title="put /journeys/{templateId}/templates/{notificationId}/locales/{localeId}">client.Journeys.Templates.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyTemplateService.PutLocale">PutLocale</a>(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, localeID <a href="https://pkg.go.dev/builtin#string">string</a>, params <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyTemplatePutLocaleParams">JourneyTemplatePutLocaleParams</a>) (\*<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#NotificationContentMutationResponse">NotificationContentMutationResponse</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code>
 - <code title="put /journeys/{templateId}/templates/{notificationId}">client.Journeys.Templates.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyTemplateService.Replace">Replace</a>(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, notificationID <a href="https://pkg.go.dev/builtin#string">string</a>, params <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyTemplateReplaceParams">JourneyTemplateReplaceParams</a>) (\*<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyTemplateGetResponse">JourneyTemplateGetResponse</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code>
 - <code title="get /journeys/{templateId}/templates/{notificationId}/content">client.Journeys.Templates.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyTemplateService.GetContent">GetContent</a>(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, notificationID <a href="https://pkg.go.dev/builtin#string">string</a>, params <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyTemplateGetContentParams">JourneyTemplateGetContentParams</a>) (\*<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#NotificationContentGetResponse">NotificationContentGetResponse</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code>
+
+## Runs
+
+Methods:
+
+- <code title="get /journeys/runs/{run_id}">client.Journeys.Runs.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyRunService.Get">Get</a>(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, runID <a href="https://pkg.go.dev/builtin#string">string</a>) (\*<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyRunResponse">JourneyRunResponse</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code>
+- <code title="get /journeys/runs">client.Journeys.Runs.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyRunService.List">List</a>(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, query <a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyRunListParams">JourneyRunListParams</a>) (\*<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyRunListResponse">JourneyRunListResponse</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code>
+- <code title="get /journeys/runs/{run_id}/steps">client.Journeys.Runs.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyRunService.ListSteps">ListSteps</a>(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, runID <a href="https://pkg.go.dev/builtin#string">string</a>) (\*<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4">courier</a>.<a href="https://pkg.go.dev/github.com/trycourier/courier-go/v4#JourneyRunStepsResponse">JourneyRunStepsResponse</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code>
 
 # Broadcasts
 

--- a/automation.go
+++ b/automation.go
@@ -31,6 +31,9 @@ type AutomationService struct {
 	// Invoke a stored automation template or an ad hoc automation defined in the
 	// request.
 	Invoke AutomationInvokeService
+	// Invoke a stored automation template or an ad hoc automation defined in the
+	// request.
+	Runs AutomationRunService
 }
 
 // NewAutomationService generates a new service that applies the given options to
@@ -40,6 +43,7 @@ func NewAutomationService(opts ...option.RequestOption) (r AutomationService) {
 	r = AutomationService{}
 	r.Options = opts
 	r.Invoke = NewAutomationInvokeService(opts...)
+	r.Runs = NewAutomationRunService(opts...)
 	return
 }
 
@@ -65,6 +69,113 @@ type AutomationInvokeResponse struct {
 // Returns the unmodified JSON received from the API
 func (r AutomationInvokeResponse) RawJSON() string { return r.JSON.raw }
 func (r *AutomationInvokeResponse) UnmarshalJSON(data []byte) error {
+	return apijson.UnmarshalRoot(data, r)
+}
+
+// An Automation run as it appears in a list response.
+type AutomationRunListItem struct {
+	// A unique identifier representing the run.
+	RunID string `json:"run_id" api:"required"`
+	// Internal provenance strings describing what started the run, e.g.
+	// `invoke/<template_id>` or `segment/page/Pricing Page`. Diagnostic only — the
+	// format is unstable and should not be parsed.
+	Source []string `json:"source" api:"required"`
+	// When the run started, as an ISO 8601 timestamp.
+	CreatedAt string `json:"created_at"`
+	// The state of the run: `PROCESSING`, `PROCESSED`, `WAITING`, `CANCELED`, `ERROR`,
+	// `THROTTLED`, or `NOT PROCESSED`. Not an enum — new values have been added
+	// before.
+	Status string `json:"status"`
+	// The id of the Automation Template this run belongs to.
+	TemplateID string `json:"template_id"`
+	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
+	JSON struct {
+		RunID       respjson.Field
+		Source      respjson.Field
+		CreatedAt   respjson.Field
+		Status      respjson.Field
+		TemplateID  respjson.Field
+		ExtraFields map[string]respjson.Field
+		raw         string
+	} `json:"-"`
+}
+
+// Returns the unmodified JSON received from the API
+func (r AutomationRunListItem) RawJSON() string { return r.JSON.raw }
+func (r *AutomationRunListItem) UnmarshalJSON(data []byte) error {
+	return apijson.UnmarshalRoot(data, r)
+}
+
+// A page of Automation runs.
+type AutomationRunListResponse struct {
+	Runs []AutomationRunListItem `json:"runs" api:"required"`
+	// Pass back as `cursor` to fetch the next page. Absent on the last page.
+	NextCursor string `json:"next_cursor"`
+	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
+	JSON struct {
+		Runs        respjson.Field
+		NextCursor  respjson.Field
+		ExtraFields map[string]respjson.Field
+		raw         string
+	} `json:"-"`
+}
+
+// Returns the unmodified JSON received from the API
+func (r AutomationRunListResponse) RawJSON() string { return r.JSON.raw }
+func (r *AutomationRunListResponse) UnmarshalJSON(data []byte) error {
+	return apijson.UnmarshalRoot(data, r)
+}
+
+// One executed step of an Automation run.
+type AutomationRunStep struct {
+	// The kind of step that ran, e.g. `send`, `delay`, or `update-profile`.
+	Action string `json:"action" api:"required"`
+	// The state of the step: the seven run statuses, plus `SKIPPED` and `COMPUTING`.
+	// Not an enum — new values have been added before.
+	Status string `json:"status" api:"required"`
+	// When the step started, as an ISO 8601 timestamp.
+	CreatedAt string `json:"created_at"`
+	// The message this step produced, present on send steps. Pass it to
+	// `GET /messages/{message_id}` for delivery status. A send to a List or an
+	// Audience yields one id for the request, not one per recipient.
+	MessageID string `json:"message_id"`
+	// A unique identifier representing the step.
+	StepID string `json:"step_id"`
+	// When the step last changed state, as an ISO 8601 timestamp.
+	UpdatedAt string `json:"updated_at"`
+	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
+	JSON struct {
+		Action      respjson.Field
+		Status      respjson.Field
+		CreatedAt   respjson.Field
+		MessageID   respjson.Field
+		StepID      respjson.Field
+		UpdatedAt   respjson.Field
+		ExtraFields map[string]respjson.Field
+		raw         string
+	} `json:"-"`
+}
+
+// Returns the unmodified JSON received from the API
+func (r AutomationRunStep) RawJSON() string { return r.JSON.raw }
+func (r *AutomationRunStep) UnmarshalJSON(data []byte) error {
+	return apijson.UnmarshalRoot(data, r)
+}
+
+// Every step of an Automation run. Not paginated.
+type AutomationRunStepsResponse struct {
+	Steps []AutomationRunStep `json:"steps" api:"required"`
+	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
+	JSON struct {
+		Steps       respjson.Field
+		ExtraFields map[string]respjson.Field
+		raw         string
+	} `json:"-"`
+}
+
+// Returns the unmodified JSON received from the API
+func (r AutomationRunStepsResponse) RawJSON() string { return r.JSON.raw }
+func (r *AutomationRunStepsResponse) UnmarshalJSON(data []byte) error {
 	return apijson.UnmarshalRoot(data, r)
 }
 

--- a/automationrun.go
+++ b/automationrun.go
@@ -1,0 +1,94 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+package courier
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+
+	"github.com/trycourier/courier-go/v4/internal/apiquery"
+	"github.com/trycourier/courier-go/v4/internal/requestconfig"
+	"github.com/trycourier/courier-go/v4/option"
+	"github.com/trycourier/courier-go/v4/packages/param"
+)
+
+// Invoke a stored automation template or an ad hoc automation defined in the
+// request.
+//
+// AutomationRunService contains methods and other services that help with
+// interacting with the Courier API.
+//
+// Note, unlike clients, this service does not read variables from the environment
+// automatically. You should not instantiate this service directly, and instead use
+// the [NewAutomationRunService] method instead.
+type AutomationRunService struct {
+	Options []option.RequestOption
+}
+
+// NewAutomationRunService generates a new service that applies the given options
+// to each request. These options are applied after the parent client's options (if
+// there is one), and before any request-specific options.
+func NewAutomationRunService(opts ...option.RequestOption) (r AutomationRunService) {
+	r = AutomationRunService{}
+	r.Options = opts
+	return
+}
+
+// List runs of the workspace's v2 Automations, newest first, filtered by status,
+// Template, or date range and paged by cursor. Journey (v3) runs are listed by
+// `GET /journeys/runs` instead — the two surfaces never return each other's runs.
+// Runs are retained for 95 days.
+func (r *AutomationRunService) List(ctx context.Context, query AutomationRunListParams, opts ...option.RequestOption) (res *AutomationRunListResponse, err error) {
+	opts = slices.Concat(r.Options, opts)
+	path := "automations/runs"
+	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, query, &res, opts...)
+	return res, err
+}
+
+// List the per-step state of one Automation run, in full — this endpoint is not
+// paginated. `message_id` is present on send steps that produced a message; follow
+// it to `GET /messages/{message_id}` for delivery status. A send to a List or an
+// Audience yields one `message_id` for the request, not one per recipient.
+func (r *AutomationRunService) ListSteps(ctx context.Context, id string, opts ...option.RequestOption) (res *AutomationRunStepsResponse, err error) {
+	opts = slices.Concat(r.Options, opts)
+	if id == "" {
+		err = errors.New("missing required id parameter")
+		return nil, err
+	}
+	path := fmt.Sprintf("automations/runs/%s/steps", id)
+	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
+	return res, err
+}
+
+type AutomationRunListParams struct {
+	// A cursor token for pagination. Use the `next_cursor` from the previous response
+	// to fetch the next page of results. Treat it as opaque.
+	Cursor param.Opt[string] `query:"cursor,omitzero" json:"-"`
+	// An inclusive upper bound on `created_at`, in the same format as `start_date`.
+	EndDate param.Opt[string] `query:"end_date,omitzero" json:"-"`
+	// The number of runs to return per page, between `1` and `50`. Defaults to `20`.
+	// Values outside the range are clamped, and a non-numeric value falls back to
+	// `20`.
+	Limit param.Opt[string] `query:"limit,omitzero" json:"-"`
+	// An inclusive lower bound on `created_at`, as an ISO 8601 date or timestamp (e.g.
+	// `2026-08-18` or `2026-08-18T20:06:36.259Z`). Any other format returns `400`.
+	StartDate param.Opt[string] `query:"start_date,omitzero" json:"-"`
+	// A comma-separated list of run statuses to filter on, e.g. `PROCESSED,ERROR`.
+	Status param.Opt[string] `query:"status,omitzero" json:"-"`
+	// A comma-separated list of Automation Template ids to filter on.
+	TemplateID param.Opt[string] `query:"template_id,omitzero" json:"-"`
+	paramObj
+}
+
+// URLQuery serializes [AutomationRunListParams]'s query parameters as
+// `url.Values`.
+func (r AutomationRunListParams) URLQuery() (v url.Values, err error) {
+	return apiquery.MarshalWithSettings(r, apiquery.QuerySettings{
+		ArrayFormat:  apiquery.ArrayQueryFormatComma,
+		NestedFormat: apiquery.NestedQueryFormatBrackets,
+	})
+}

--- a/automationrun_test.go
+++ b/automationrun_test.go
@@ -1,0 +1,67 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+package courier_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/trycourier/courier-go/v4"
+	"github.com/trycourier/courier-go/v4/internal/testutil"
+	"github.com/trycourier/courier-go/v4/option"
+)
+
+func TestAutomationRunListWithOptionalParams(t *testing.T) {
+	t.Skip("Mock server tests are disabled")
+	baseURL := "http://localhost:4010"
+	if envURL, ok := os.LookupEnv("TEST_API_BASE_URL"); ok {
+		baseURL = envURL
+	}
+	if !testutil.CheckTestServer(t, baseURL) {
+		return
+	}
+	client := courier.NewClient(
+		option.WithBaseURL(baseURL),
+		option.WithAPIKey("My API Key"),
+	)
+	_, err := client.Automations.Runs.List(context.TODO(), courier.AutomationRunListParams{
+		Cursor:     courier.String("cursor"),
+		EndDate:    courier.String("end_date"),
+		Limit:      courier.String("321669910225"),
+		StartDate:  courier.String("start_date"),
+		Status:     courier.String("status"),
+		TemplateID: courier.String("template_id"),
+	})
+	if err != nil {
+		var apierr *courier.Error
+		if errors.As(err, &apierr) {
+			t.Log(string(apierr.DumpRequest(true)))
+		}
+		t.Fatalf("err should be nil: %s", err.Error())
+	}
+}
+
+func TestAutomationRunListSteps(t *testing.T) {
+	t.Skip("Mock server tests are disabled")
+	baseURL := "http://localhost:4010"
+	if envURL, ok := os.LookupEnv("TEST_API_BASE_URL"); ok {
+		baseURL = envURL
+	}
+	if !testutil.CheckTestServer(t, baseURL) {
+		return
+	}
+	client := courier.NewClient(
+		option.WithBaseURL(baseURL),
+		option.WithAPIKey("My API Key"),
+	)
+	_, err := client.Automations.Runs.ListSteps(context.TODO(), "x")
+	if err != nil {
+		var apierr *courier.Error
+		if errors.As(err, &apierr) {
+			t.Log(string(apierr.DumpRequest(true)))
+		}
+		t.Fatalf("err should be nil: %s", err.Error())
+	}
+}

--- a/journey.go
+++ b/journey.go
@@ -36,6 +36,9 @@ type JourneyService struct {
 	// Build, version, publish, invoke, and cancel multi-step notification workflows,
 	// along with the templates scoped to them.
 	Templates JourneyTemplateService
+	// Build, version, publish, invoke, and cancel multi-step notification workflows,
+	// along with the templates scoped to them.
+	Runs JourneyRunService
 }
 
 // NewJourneyService generates a new service that applies the given options to each
@@ -45,6 +48,7 @@ func NewJourneyService(opts ...option.RequestOption) (r JourneyService) {
 	r = JourneyService{}
 	r.Options = opts
 	r.Templates = NewJourneyTemplateService(opts...)
+	r.Runs = NewJourneyRunService(opts...)
 	return
 }
 
@@ -534,6 +538,95 @@ func (r JourneyAPIInvokeTriggerNodeParam) MarshalJSON() (data []byte, err error)
 	return param.MarshalObject(r, (*shadow)(&r))
 }
 func (r *JourneyAPIInvokeTriggerNodeParam) UnmarshalJSON(data []byte) error {
+	return apijson.UnmarshalRoot(data, r)
+}
+
+// Trigger fired when a user newly matches an Audience. Leaving and re-joining the
+// Audience re-enters the Journey. Membership is new-members-only: users already in
+// the Audience when the Journey is published do not enter. Unlike the v2
+// Automations audience trigger, there is no member scope, event type, or frequency
+// mode to configure, and `audience_id` must name one Audience — wildcards are not
+// supported.
+type JourneyAudienceTriggerNode struct {
+	// The Audience to watch. Must name a single Audience; wildcards are not supported.
+	AudienceID string `json:"audience_id" api:"required"`
+	// Any of "audience".
+	TriggerType JourneyAudienceTriggerNodeTriggerType `json:"trigger_type" api:"required"`
+	// Any of "trigger".
+	Type JourneyAudienceTriggerNodeType `json:"type" api:"required"`
+	ID   string                         `json:"id"`
+	// Condition spec for a journey node. Accepts a single condition atom, an AND/OR
+	// group, or an AND/OR nested group. Omit the `conditions` property entirely to
+	// express "no conditions".
+	Conditions JourneyConditionsFieldUnion `json:"conditions"`
+	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
+	JSON struct {
+		AudienceID  respjson.Field
+		TriggerType respjson.Field
+		Type        respjson.Field
+		ID          respjson.Field
+		Conditions  respjson.Field
+		ExtraFields map[string]respjson.Field
+		raw         string
+	} `json:"-"`
+}
+
+// Returns the unmodified JSON received from the API
+func (r JourneyAudienceTriggerNode) RawJSON() string { return r.JSON.raw }
+func (r *JourneyAudienceTriggerNode) UnmarshalJSON(data []byte) error {
+	return apijson.UnmarshalRoot(data, r)
+}
+
+// ToParam converts this JourneyAudienceTriggerNode to a
+// JourneyAudienceTriggerNodeParam.
+//
+// Warning: the fields of the param type will not be present. ToParam should only
+// be used at the last possible moment before sending a request. Test for this with
+// JourneyAudienceTriggerNodeParam.Overrides()
+func (r JourneyAudienceTriggerNode) ToParam() JourneyAudienceTriggerNodeParam {
+	return param.Override[JourneyAudienceTriggerNodeParam](json.RawMessage(r.RawJSON()))
+}
+
+type JourneyAudienceTriggerNodeTriggerType string
+
+const (
+	JourneyAudienceTriggerNodeTriggerTypeAudience JourneyAudienceTriggerNodeTriggerType = "audience"
+)
+
+type JourneyAudienceTriggerNodeType string
+
+const (
+	JourneyAudienceTriggerNodeTypeTrigger JourneyAudienceTriggerNodeType = "trigger"
+)
+
+// Trigger fired when a user newly matches an Audience. Leaving and re-joining the
+// Audience re-enters the Journey. Membership is new-members-only: users already in
+// the Audience when the Journey is published do not enter. Unlike the v2
+// Automations audience trigger, there is no member scope, event type, or frequency
+// mode to configure, and `audience_id` must name one Audience — wildcards are not
+// supported.
+//
+// The properties AudienceID, TriggerType, Type are required.
+type JourneyAudienceTriggerNodeParam struct {
+	// The Audience to watch. Must name a single Audience; wildcards are not supported.
+	AudienceID string `json:"audience_id" api:"required"`
+	// Any of "audience".
+	TriggerType JourneyAudienceTriggerNodeTriggerType `json:"trigger_type,omitzero" api:"required"`
+	// Any of "trigger".
+	Type JourneyAudienceTriggerNodeType `json:"type,omitzero" api:"required"`
+	ID   param.Opt[string]              `json:"id,omitzero"`
+	// Condition spec for a journey node. Accepts a single condition atom, an AND/OR
+	// group, or an AND/OR nested group. Omit the `conditions` property entirely to
+	// express "no conditions".
+	Conditions JourneyConditionsFieldUnionParam `json:"conditions,omitzero"`
+	paramObj
+}
+
+func (r JourneyAudienceTriggerNodeParam) MarshalJSON() (data []byte, err error) {
+	type shadow JourneyAudienceTriggerNodeParam
+	return param.MarshalObject(r, (*shadow)(&r))
+}
+func (r *JourneyAudienceTriggerNodeParam) UnmarshalJSON(data []byte) error {
 	return apijson.UnmarshalRoot(data, r)
 }
 
@@ -1369,7 +1462,8 @@ const (
 )
 
 // JourneyNodeUnion contains all possible properties and values from
-// [JourneyAPIInvokeTriggerNode], [JourneySegmentTriggerNode], [JourneySendNode],
+// [JourneyAPIInvokeTriggerNode], [JourneySegmentTriggerNode],
+// [JourneyAudienceTriggerNode], [JourneyWebhookTriggerNode], [JourneySendNode],
 // [JourneyDelayDurationNode], [JourneyDelayUntilNode],
 // [JourneyFetchGetDeleteNode], [JourneyFetchPostPutNode], [JourneyAINode],
 // [JourneyThrottleStaticNode], [JourneyThrottleDynamicNode], [JourneyNodeBatch],
@@ -1386,8 +1480,11 @@ type JourneyNodeUnion struct {
 	Schema map[string]any `json:"schema"`
 	// This field is from variant [JourneySegmentTriggerNode].
 	RequestType JourneySegmentTriggerNodeRequestType `json:"request_type"`
-	// This field is from variant [JourneySegmentTriggerNode].
-	EventID string `json:"event_id"`
+	EventID     string                               `json:"event_id"`
+	// This field is from variant [JourneyAudienceTriggerNode].
+	AudienceID string `json:"audience_id"`
+	// This field is from variant [JourneyWebhookTriggerNode].
+	EventSource string `json:"event_source"`
 	// This field is from variant [JourneySendNode].
 	Message JourneySendNodeMessage `json:"message"`
 	// This field is from variant [JourneySendNode].
@@ -1443,6 +1540,8 @@ type JourneyNodeUnion struct {
 		Schema              respjson.Field
 		RequestType         respjson.Field
 		EventID             respjson.Field
+		AudienceID          respjson.Field
+		EventSource         respjson.Field
 		Message             respjson.Field
 		Experiment          respjson.Field
 		Duration            respjson.Field
@@ -1481,6 +1580,16 @@ func (u JourneyNodeUnion) AsAPIInvokeTrigger() (v JourneyAPIInvokeTriggerNode) {
 }
 
 func (u JourneyNodeUnion) AsSegmentTrigger() (v JourneySegmentTriggerNode) {
+	apijson.UnmarshalRoot(json.RawMessage(u.JSON.raw), &v)
+	return
+}
+
+func (u JourneyNodeUnion) AsAudienceTrigger() (v JourneyAudienceTriggerNode) {
+	apijson.UnmarshalRoot(json.RawMessage(u.JSON.raw), &v)
+	return
+}
+
+func (u JourneyNodeUnion) AsWebhookTrigger() (v JourneyWebhookTriggerNode) {
 	apijson.UnmarshalRoot(json.RawMessage(u.JSON.raw), &v)
 	return
 }
@@ -1748,6 +1857,22 @@ func JourneyNodeParamOfSegmentTrigger(requestType JourneySegmentTriggerNodeReque
 	return JourneyNodeUnionParam{OfSegmentTrigger: &variant}
 }
 
+func JourneyNodeParamOfAudienceTrigger(audienceID string, triggerType JourneyAudienceTriggerNodeTriggerType, type_ JourneyAudienceTriggerNodeType) JourneyNodeUnionParam {
+	var variant JourneyAudienceTriggerNodeParam
+	variant.AudienceID = audienceID
+	variant.TriggerType = triggerType
+	variant.Type = type_
+	return JourneyNodeUnionParam{OfAudienceTrigger: &variant}
+}
+
+func JourneyNodeParamOfWebhookTrigger(eventSource string, triggerType JourneyWebhookTriggerNodeTriggerType, type_ JourneyWebhookTriggerNodeType) JourneyNodeUnionParam {
+	var variant JourneyWebhookTriggerNodeParam
+	variant.EventSource = eventSource
+	variant.TriggerType = triggerType
+	variant.Type = type_
+	return JourneyNodeUnionParam{OfWebhookTrigger: &variant}
+}
+
 func JourneyNodeParamOfSend(message JourneySendNodeMessageParam, type_ JourneySendNodeType) JourneyNodeUnionParam {
 	var variant JourneySendNodeParam
 	variant.Message = message
@@ -1805,6 +1930,8 @@ func JourneyNodeParamOfJourneyBranchNode(default_ JourneyNodeJourneyBranchNodeDe
 type JourneyNodeUnionParam struct {
 	OfAPIInvokeTrigger  *JourneyAPIInvokeTriggerNodeParam  `json:",omitzero,inline"`
 	OfSegmentTrigger    *JourneySegmentTriggerNodeParam    `json:",omitzero,inline"`
+	OfAudienceTrigger   *JourneyAudienceTriggerNodeParam   `json:",omitzero,inline"`
+	OfWebhookTrigger    *JourneyWebhookTriggerNodeParam    `json:",omitzero,inline"`
 	OfSend              *JourneySendNodeParam              `json:",omitzero,inline"`
 	OfDelayForDuration  *JourneyDelayDurationNodeParam     `json:",omitzero,inline"`
 	OfDelayUntil        *JourneyDelayUntilNodeParam        `json:",omitzero,inline"`
@@ -1823,6 +1950,8 @@ type JourneyNodeUnionParam struct {
 func (u JourneyNodeUnionParam) MarshalJSON() ([]byte, error) {
 	return param.MarshalUnion(u, u.OfAPIInvokeTrigger,
 		u.OfSegmentTrigger,
+		u.OfAudienceTrigger,
+		u.OfWebhookTrigger,
 		u.OfSend,
 		u.OfDelayForDuration,
 		u.OfDelayUntil,
@@ -1845,6 +1974,10 @@ func (u *JourneyNodeUnionParam) asAny() any {
 		return u.OfAPIInvokeTrigger
 	} else if !param.IsOmitted(u.OfSegmentTrigger) {
 		return u.OfSegmentTrigger
+	} else if !param.IsOmitted(u.OfAudienceTrigger) {
+		return u.OfAudienceTrigger
+	} else if !param.IsOmitted(u.OfWebhookTrigger) {
+		return u.OfWebhookTrigger
 	} else if !param.IsOmitted(u.OfSend) {
 		return u.OfSend
 	} else if !param.IsOmitted(u.OfDelayForDuration) {
@@ -1890,9 +2023,17 @@ func (u JourneyNodeUnionParam) GetRequestType() *string {
 }
 
 // Returns a pointer to the underlying variant's property, if present.
-func (u JourneyNodeUnionParam) GetEventID() *string {
-	if vt := u.OfSegmentTrigger; vt != nil && vt.EventID.Valid() {
-		return &vt.EventID.Value
+func (u JourneyNodeUnionParam) GetAudienceID() *string {
+	if vt := u.OfAudienceTrigger; vt != nil {
+		return &vt.AudienceID
+	}
+	return nil
+}
+
+// Returns a pointer to the underlying variant's property, if present.
+func (u JourneyNodeUnionParam) GetEventSource() *string {
+	if vt := u.OfWebhookTrigger; vt != nil {
+		return &vt.EventSource
 	}
 	return nil
 }
@@ -2047,6 +2188,10 @@ func (u JourneyNodeUnionParam) GetTriggerType() *string {
 		return (*string)(&vt.TriggerType)
 	} else if vt := u.OfSegmentTrigger; vt != nil {
 		return (*string)(&vt.TriggerType)
+	} else if vt := u.OfAudienceTrigger; vt != nil {
+		return (*string)(&vt.TriggerType)
+	} else if vt := u.OfWebhookTrigger; vt != nil {
+		return (*string)(&vt.TriggerType)
 	}
 	return nil
 }
@@ -2056,6 +2201,10 @@ func (u JourneyNodeUnionParam) GetType() *string {
 	if vt := u.OfAPIInvokeTrigger; vt != nil {
 		return (*string)(&vt.Type)
 	} else if vt := u.OfSegmentTrigger; vt != nil {
+		return (*string)(&vt.Type)
+	} else if vt := u.OfAudienceTrigger; vt != nil {
+		return (*string)(&vt.Type)
+	} else if vt := u.OfWebhookTrigger; vt != nil {
 		return (*string)(&vt.Type)
 	} else if vt := u.OfSend; vt != nil {
 		return (*string)(&vt.Type)
@@ -2091,6 +2240,10 @@ func (u JourneyNodeUnionParam) GetID() *string {
 		return &vt.ID.Value
 	} else if vt := u.OfSegmentTrigger; vt != nil && vt.ID.Valid() {
 		return &vt.ID.Value
+	} else if vt := u.OfAudienceTrigger; vt != nil && vt.ID.Valid() {
+		return &vt.ID.Value
+	} else if vt := u.OfWebhookTrigger; vt != nil && vt.ID.Valid() {
+		return &vt.ID.Value
 	} else if vt := u.OfSend; vt != nil && vt.ID.Valid() {
 		return &vt.ID.Value
 	} else if vt := u.OfDelayForDuration; vt != nil && vt.ID.Valid() {
@@ -2115,6 +2268,16 @@ func (u JourneyNodeUnionParam) GetID() *string {
 		return &vt.ID.Value
 	} else if vt := u.OfJourneyBranchNode; vt != nil && vt.ID.Valid() {
 		return &vt.ID.Value
+	}
+	return nil
+}
+
+// Returns a pointer to the underlying variant's property, if present.
+func (u JourneyNodeUnionParam) GetEventID() *string {
+	if vt := u.OfSegmentTrigger; vt != nil && vt.EventID.Valid() {
+		return &vt.EventID.Value
+	} else if vt := u.OfWebhookTrigger; vt != nil && vt.EventID.Valid() {
+		return &vt.EventID.Value
 	}
 	return nil
 }
@@ -2196,6 +2359,10 @@ func (u JourneyNodeUnionParam) GetConditions() *JourneyConditionsFieldUnionParam
 	if vt := u.OfAPIInvokeTrigger; vt != nil {
 		return &vt.Conditions
 	} else if vt := u.OfSegmentTrigger; vt != nil {
+		return &vt.Conditions
+	} else if vt := u.OfAudienceTrigger; vt != nil {
+		return &vt.Conditions
+	} else if vt := u.OfWebhookTrigger; vt != nil {
 		return &vt.Conditions
 	} else if vt := u.OfSend; vt != nil {
 		return &vt.Conditions
@@ -2477,9 +2644,176 @@ func (r *JourneyResponse) UnmarshalJSON(data []byte) error {
 	return apijson.UnmarshalRoot(data, r)
 }
 
-// Trigger fired by a segment event (`identify`, `group`, or `track`).
+// One run of a Journey. `status` and `created_at` are absent on a small number of
+// legacy runs stored without them.
+type JourneyRun struct {
+	// A unique identifier representing the run.
+	RunID string `json:"run_id" api:"required"`
+	// Internal provenance strings describing what started the run, e.g.
+	// `invoke/<journey_id>` or `segment/page/Pricing Page`. Diagnostic only — the
+	// format is unstable and should not be parsed.
+	Source []string `json:"source" api:"required"`
+	// When the run started, as an ISO 8601 timestamp.
+	CreatedAt string `json:"created_at"`
+	// The state of the run: `PROCESSING`, `PROCESSED`, `WAITING`, `CANCELED`, `ERROR`,
+	// `THROTTLED`, or `NOT PROCESSED`. Not an enum — new values have been added
+	// before.
+	Status string `json:"status"`
+	// The id of the Journey this run belongs to.
+	TemplateID string `json:"template_id"`
+	// When the run last changed state, as an ISO 8601 timestamp.
+	UpdatedAt string `json:"updated_at"`
+	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
+	JSON struct {
+		RunID       respjson.Field
+		Source      respjson.Field
+		CreatedAt   respjson.Field
+		Status      respjson.Field
+		TemplateID  respjson.Field
+		UpdatedAt   respjson.Field
+		ExtraFields map[string]respjson.Field
+		raw         string
+	} `json:"-"`
+}
+
+// Returns the unmodified JSON received from the API
+func (r JourneyRun) RawJSON() string { return r.JSON.raw }
+func (r *JourneyRun) UnmarshalJSON(data []byte) error {
+	return apijson.UnmarshalRoot(data, r)
+}
+
+// A Journey run as it appears in a list response, without `updated_at`.
+type JourneyRunListItem struct {
+	// A unique identifier representing the run.
+	RunID string `json:"run_id" api:"required"`
+	// Internal provenance strings describing what started the run. Diagnostic only.
+	Source []string `json:"source" api:"required"`
+	// When the run started, as an ISO 8601 timestamp.
+	CreatedAt string `json:"created_at"`
+	// The state of the run. See `JourneyRun.status` for the values it takes.
+	Status string `json:"status"`
+	// The id of the Journey this run belongs to.
+	TemplateID string `json:"template_id"`
+	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
+	JSON struct {
+		RunID       respjson.Field
+		Source      respjson.Field
+		CreatedAt   respjson.Field
+		Status      respjson.Field
+		TemplateID  respjson.Field
+		ExtraFields map[string]respjson.Field
+		raw         string
+	} `json:"-"`
+}
+
+// Returns the unmodified JSON received from the API
+func (r JourneyRunListItem) RawJSON() string { return r.JSON.raw }
+func (r *JourneyRunListItem) UnmarshalJSON(data []byte) error {
+	return apijson.UnmarshalRoot(data, r)
+}
+
+// A page of Journey runs.
+type JourneyRunListResponse struct {
+	Runs []JourneyRunListItem `json:"runs" api:"required"`
+	// Pass back as `cursor` to fetch the next page. Absent on the last page.
+	NextCursor string `json:"next_cursor"`
+	// Pass back as `cursor` to fetch the previous page. Absent on the first page.
+	PrevCursor string `json:"prev_cursor"`
+	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
+	JSON struct {
+		Runs        respjson.Field
+		NextCursor  respjson.Field
+		PrevCursor  respjson.Field
+		ExtraFields map[string]respjson.Field
+		raw         string
+	} `json:"-"`
+}
+
+// Returns the unmodified JSON received from the API
+func (r JourneyRunListResponse) RawJSON() string { return r.JSON.raw }
+func (r *JourneyRunListResponse) UnmarshalJSON(data []byte) error {
+	return apijson.UnmarshalRoot(data, r)
+}
+
+// A single Journey run.
+type JourneyRunResponse struct {
+	// One run of a Journey. `status` and `created_at` are absent on a small number of
+	// legacy runs stored without them.
+	Run JourneyRun `json:"run" api:"required"`
+	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
+	JSON struct {
+		Run         respjson.Field
+		ExtraFields map[string]respjson.Field
+		raw         string
+	} `json:"-"`
+}
+
+// Returns the unmodified JSON received from the API
+func (r JourneyRunResponse) RawJSON() string { return r.JSON.raw }
+func (r *JourneyRunResponse) UnmarshalJSON(data []byte) error {
+	return apijson.UnmarshalRoot(data, r)
+}
+
+// One executed node of a Journey run. `node_id` is the id of the node in the
+// published Journey, so a step maps directly onto the Journey graph.
+type JourneyRunStep struct {
+	// The kind of node that ran, e.g. `send`, `delay`, or `exit`.
+	Action string `json:"action" api:"required"`
+	// The state of the step: the seven run statuses, plus `SKIPPED` and `COMPUTING`.
+	// Not an enum — new values have been added before.
+	Status string `json:"status" api:"required"`
+	// When the step started, as an ISO 8601 timestamp.
+	CreatedAt string `json:"created_at"`
+	// The message this step produced, present on send steps. Pass it to
+	// `GET /messages/{message_id}` for delivery status. A send to a List or an
+	// Audience yields one id for the request, not one per recipient.
+	MessageID string `json:"message_id"`
+	// The id of the node in the published Journey that this step executed.
+	NodeID string `json:"node_id"`
+	// When the step last changed state, as an ISO 8601 timestamp.
+	UpdatedAt string `json:"updated_at"`
+	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
+	JSON struct {
+		Action      respjson.Field
+		Status      respjson.Field
+		CreatedAt   respjson.Field
+		MessageID   respjson.Field
+		NodeID      respjson.Field
+		UpdatedAt   respjson.Field
+		ExtraFields map[string]respjson.Field
+		raw         string
+	} `json:"-"`
+}
+
+// Returns the unmodified JSON received from the API
+func (r JourneyRunStep) RawJSON() string { return r.JSON.raw }
+func (r *JourneyRunStep) UnmarshalJSON(data []byte) error {
+	return apijson.UnmarshalRoot(data, r)
+}
+
+// Every step of a Journey run. Not paginated.
+type JourneyRunStepsResponse struct {
+	Steps []JourneyRunStep `json:"steps" api:"required"`
+	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
+	JSON struct {
+		Steps       respjson.Field
+		ExtraFields map[string]respjson.Field
+		raw         string
+	} `json:"-"`
+}
+
+// Returns the unmodified JSON received from the API
+func (r JourneyRunStepsResponse) RawJSON() string { return r.JSON.raw }
+func (r *JourneyRunStepsResponse) UnmarshalJSON(data []byte) error {
+	return apijson.UnmarshalRoot(data, r)
+}
+
+// Trigger fired by a segment event (`identify`, `group`, `track`, or `page`). A
+// trigger with no `event_id` fires on any event of its type — the only shape
+// `identify` and `group` can take, and the one that catches a stock
+// `analytics.page()` call.
 type JourneySegmentTriggerNode struct {
-	// Any of "identify", "group", "track".
+	// Any of "identify", "group", "track", "page".
 	RequestType JourneySegmentTriggerNodeRequestType `json:"request_type" api:"required"`
 	// Any of "segment".
 	TriggerType JourneySegmentTriggerNodeTriggerType `json:"trigger_type" api:"required"`
@@ -2526,6 +2860,7 @@ const (
 	JourneySegmentTriggerNodeRequestTypeIdentify JourneySegmentTriggerNodeRequestType = "identify"
 	JourneySegmentTriggerNodeRequestTypeGroup    JourneySegmentTriggerNodeRequestType = "group"
 	JourneySegmentTriggerNodeRequestTypeTrack    JourneySegmentTriggerNodeRequestType = "track"
+	JourneySegmentTriggerNodeRequestTypePage     JourneySegmentTriggerNodeRequestType = "page"
 )
 
 type JourneySegmentTriggerNodeTriggerType string
@@ -2540,11 +2875,14 @@ const (
 	JourneySegmentTriggerNodeTypeTrigger JourneySegmentTriggerNodeType = "trigger"
 )
 
-// Trigger fired by a segment event (`identify`, `group`, or `track`).
+// Trigger fired by a segment event (`identify`, `group`, `track`, or `page`). A
+// trigger with no `event_id` fires on any event of its type — the only shape
+// `identify` and `group` can take, and the one that catches a stock
+// `analytics.page()` call.
 //
 // The properties RequestType, TriggerType, Type are required.
 type JourneySegmentTriggerNodeParam struct {
-	// Any of "identify", "group", "track".
+	// Any of "identify", "group", "track", "page".
 	RequestType JourneySegmentTriggerNodeRequestType `json:"request_type,omitzero" api:"required"`
 	// Any of "segment".
 	TriggerType JourneySegmentTriggerNodeTriggerType `json:"trigger_type,omitzero" api:"required"`
@@ -3383,6 +3721,100 @@ type JourneyVersionsListResponse struct {
 // Returns the unmodified JSON received from the API
 func (r JourneyVersionsListResponse) RawJSON() string { return r.JSON.raw }
 func (r *JourneyVersionsListResponse) UnmarshalJSON(data []byte) error {
+	return apijson.UnmarshalRoot(data, r)
+}
+
+// Trigger fired when an external system POSTs to the webhook URL minted for
+// `event_source`. Narrow it to one event with `event_id`, or omit `event_id` to
+// accept every event delivered to the URL.
+type JourneyWebhookTriggerNode struct {
+	// The provider key the webhook URL is minted for. Required, and must not contain a
+	// forward slash.
+	EventSource string `json:"event_source" api:"required"`
+	// Any of "webhook".
+	TriggerType JourneyWebhookTriggerNodeTriggerType `json:"trigger_type" api:"required"`
+	// Any of "trigger".
+	Type JourneyWebhookTriggerNodeType `json:"type" api:"required"`
+	ID   string                        `json:"id"`
+	// Condition spec for a journey node. Accepts a single condition atom, an AND/OR
+	// group, or an AND/OR nested group. Omit the `conditions` property entirely to
+	// express "no conditions".
+	Conditions JourneyConditionsFieldUnion `json:"conditions"`
+	// An optional event filter, matched against the payload's `event` field. A sender
+	// that supplies no `event` matches the literal `custom`. Must not contain a
+	// forward slash. Omit to accept every event delivered to the URL.
+	EventID string `json:"event_id"`
+	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
+	JSON struct {
+		EventSource respjson.Field
+		TriggerType respjson.Field
+		Type        respjson.Field
+		ID          respjson.Field
+		Conditions  respjson.Field
+		EventID     respjson.Field
+		ExtraFields map[string]respjson.Field
+		raw         string
+	} `json:"-"`
+}
+
+// Returns the unmodified JSON received from the API
+func (r JourneyWebhookTriggerNode) RawJSON() string { return r.JSON.raw }
+func (r *JourneyWebhookTriggerNode) UnmarshalJSON(data []byte) error {
+	return apijson.UnmarshalRoot(data, r)
+}
+
+// ToParam converts this JourneyWebhookTriggerNode to a
+// JourneyWebhookTriggerNodeParam.
+//
+// Warning: the fields of the param type will not be present. ToParam should only
+// be used at the last possible moment before sending a request. Test for this with
+// JourneyWebhookTriggerNodeParam.Overrides()
+func (r JourneyWebhookTriggerNode) ToParam() JourneyWebhookTriggerNodeParam {
+	return param.Override[JourneyWebhookTriggerNodeParam](json.RawMessage(r.RawJSON()))
+}
+
+type JourneyWebhookTriggerNodeTriggerType string
+
+const (
+	JourneyWebhookTriggerNodeTriggerTypeWebhook JourneyWebhookTriggerNodeTriggerType = "webhook"
+)
+
+type JourneyWebhookTriggerNodeType string
+
+const (
+	JourneyWebhookTriggerNodeTypeTrigger JourneyWebhookTriggerNodeType = "trigger"
+)
+
+// Trigger fired when an external system POSTs to the webhook URL minted for
+// `event_source`. Narrow it to one event with `event_id`, or omit `event_id` to
+// accept every event delivered to the URL.
+//
+// The properties EventSource, TriggerType, Type are required.
+type JourneyWebhookTriggerNodeParam struct {
+	// The provider key the webhook URL is minted for. Required, and must not contain a
+	// forward slash.
+	EventSource string `json:"event_source" api:"required"`
+	// Any of "webhook".
+	TriggerType JourneyWebhookTriggerNodeTriggerType `json:"trigger_type,omitzero" api:"required"`
+	// Any of "trigger".
+	Type JourneyWebhookTriggerNodeType `json:"type,omitzero" api:"required"`
+	ID   param.Opt[string]             `json:"id,omitzero"`
+	// An optional event filter, matched against the payload's `event` field. A sender
+	// that supplies no `event` matches the literal `custom`. Must not contain a
+	// forward slash. Omit to accept every event delivered to the URL.
+	EventID param.Opt[string] `json:"event_id,omitzero"`
+	// Condition spec for a journey node. Accepts a single condition atom, an AND/OR
+	// group, or an AND/OR nested group. Omit the `conditions` property entirely to
+	// express "no conditions".
+	Conditions JourneyConditionsFieldUnionParam `json:"conditions,omitzero"`
+	paramObj
+}
+
+func (r JourneyWebhookTriggerNodeParam) MarshalJSON() (data []byte, err error) {
+	type shadow JourneyWebhookTriggerNodeParam
+	return param.MarshalObject(r, (*shadow)(&r))
+}
+func (r *JourneyWebhookTriggerNodeParam) UnmarshalJSON(data []byte) error {
 	return apijson.UnmarshalRoot(data, r)
 }
 

--- a/journeyrun.go
+++ b/journeyrun.go
@@ -1,0 +1,109 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+package courier
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+
+	"github.com/trycourier/courier-go/v4/internal/apiquery"
+	"github.com/trycourier/courier-go/v4/internal/requestconfig"
+	"github.com/trycourier/courier-go/v4/option"
+	"github.com/trycourier/courier-go/v4/packages/param"
+)
+
+// Build, version, publish, invoke, and cancel multi-step notification workflows,
+// along with the templates scoped to them.
+//
+// JourneyRunService contains methods and other services that help with interacting
+// with the Courier API.
+//
+// Note, unlike clients, this service does not read variables from the environment
+// automatically. You should not instantiate this service directly, and instead use
+// the [NewJourneyRunService] method instead.
+type JourneyRunService struct {
+	Options []option.RequestOption
+}
+
+// NewJourneyRunService generates a new service that applies the given options to
+// each request. These options are applied after the parent client's options (if
+// there is one), and before any request-specific options.
+func NewJourneyRunService(opts ...option.RequestOption) (r JourneyRunService) {
+	r = JourneyRunService{}
+	r.Options = opts
+	return
+}
+
+// Fetch one Journey run by id. Returns `404` for an unknown run, a run belonging
+// to another workspace, a run past the 95-day retention window, or an Automation
+// run id — the same body in every case, so the response never reveals whether a
+// run exists elsewhere.
+func (r *JourneyRunService) Get(ctx context.Context, runID string, opts ...option.RequestOption) (res *JourneyRunResponse, err error) {
+	opts = slices.Concat(r.Options, opts)
+	if runID == "" {
+		err = errors.New("missing required run_id parameter")
+		return nil, err
+	}
+	path := fmt.Sprintf("journeys/runs/%s", runID)
+	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
+	return res, err
+}
+
+// List runs of the workspace's Journeys, newest first, filtered by status,
+// Journey, or date range and paged by cursor. Runs of v2 Automations are listed by
+// `GET /automations/runs` instead — the two surfaces never return each other's
+// runs. Runs are retained for 95 days.
+func (r *JourneyRunService) List(ctx context.Context, query JourneyRunListParams, opts ...option.RequestOption) (res *JourneyRunListResponse, err error) {
+	opts = slices.Concat(r.Options, opts)
+	path := "journeys/runs"
+	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, query, &res, opts...)
+	return res, err
+}
+
+// List the per-node state of one Journey run, in full — this endpoint is not
+// paginated. Each step's `node_id` is the id of the node in the published Journey,
+// so a step maps directly onto the Journey graph. `message_id` is present on send
+// steps that produced a message; follow it to `GET /messages/{message_id}` for
+// delivery status.
+func (r *JourneyRunService) ListSteps(ctx context.Context, runID string, opts ...option.RequestOption) (res *JourneyRunStepsResponse, err error) {
+	opts = slices.Concat(r.Options, opts)
+	if runID == "" {
+		err = errors.New("missing required run_id parameter")
+		return nil, err
+	}
+	path := fmt.Sprintf("journeys/runs/%s/steps", runID)
+	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
+	return res, err
+}
+
+type JourneyRunListParams struct {
+	// A cursor token for pagination. Use the `next_cursor` from the previous response
+	// to fetch the next page of results. Treat it as opaque.
+	Cursor param.Opt[string] `query:"cursor,omitzero" json:"-"`
+	// An inclusive upper bound on `created_at`, in the same format as `start_date`.
+	EndDate param.Opt[string] `query:"end_date,omitzero" json:"-"`
+	// The number of runs to return per page, between `1` and `50`. Defaults to `20`.
+	// Values outside the range are clamped, and a non-numeric value falls back to
+	// `20`.
+	Limit param.Opt[string] `query:"limit,omitzero" json:"-"`
+	// An inclusive lower bound on `created_at`, as an ISO 8601 date or timestamp (e.g.
+	// `2026-08-18` or `2026-08-18T20:06:36.259Z`). Any other format returns `400`.
+	StartDate param.Opt[string] `query:"start_date,omitzero" json:"-"`
+	// A comma-separated list of run statuses to filter on, e.g. `PROCESSED,ERROR`.
+	Status param.Opt[string] `query:"status,omitzero" json:"-"`
+	// A comma-separated list of Journey ids to filter on.
+	TemplateID param.Opt[string] `query:"template_id,omitzero" json:"-"`
+	paramObj
+}
+
+// URLQuery serializes [JourneyRunListParams]'s query parameters as `url.Values`.
+func (r JourneyRunListParams) URLQuery() (v url.Values, err error) {
+	return apiquery.MarshalWithSettings(r, apiquery.QuerySettings{
+		ArrayFormat:  apiquery.ArrayQueryFormatComma,
+		NestedFormat: apiquery.NestedQueryFormatBrackets,
+	})
+}

--- a/journeyrun_test.go
+++ b/journeyrun_test.go
@@ -1,0 +1,90 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+package courier_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/trycourier/courier-go/v4"
+	"github.com/trycourier/courier-go/v4/internal/testutil"
+	"github.com/trycourier/courier-go/v4/option"
+)
+
+func TestJourneyRunGet(t *testing.T) {
+	t.Skip("Mock server tests are disabled")
+	baseURL := "http://localhost:4010"
+	if envURL, ok := os.LookupEnv("TEST_API_BASE_URL"); ok {
+		baseURL = envURL
+	}
+	if !testutil.CheckTestServer(t, baseURL) {
+		return
+	}
+	client := courier.NewClient(
+		option.WithBaseURL(baseURL),
+		option.WithAPIKey("My API Key"),
+	)
+	_, err := client.Journeys.Runs.Get(context.TODO(), "x")
+	if err != nil {
+		var apierr *courier.Error
+		if errors.As(err, &apierr) {
+			t.Log(string(apierr.DumpRequest(true)))
+		}
+		t.Fatalf("err should be nil: %s", err.Error())
+	}
+}
+
+func TestJourneyRunListWithOptionalParams(t *testing.T) {
+	t.Skip("Mock server tests are disabled")
+	baseURL := "http://localhost:4010"
+	if envURL, ok := os.LookupEnv("TEST_API_BASE_URL"); ok {
+		baseURL = envURL
+	}
+	if !testutil.CheckTestServer(t, baseURL) {
+		return
+	}
+	client := courier.NewClient(
+		option.WithBaseURL(baseURL),
+		option.WithAPIKey("My API Key"),
+	)
+	_, err := client.Journeys.Runs.List(context.TODO(), courier.JourneyRunListParams{
+		Cursor:     courier.String("cursor"),
+		EndDate:    courier.String("end_date"),
+		Limit:      courier.String("321669910225"),
+		StartDate:  courier.String("start_date"),
+		Status:     courier.String("status"),
+		TemplateID: courier.String("template_id"),
+	})
+	if err != nil {
+		var apierr *courier.Error
+		if errors.As(err, &apierr) {
+			t.Log(string(apierr.DumpRequest(true)))
+		}
+		t.Fatalf("err should be nil: %s", err.Error())
+	}
+}
+
+func TestJourneyRunListSteps(t *testing.T) {
+	t.Skip("Mock server tests are disabled")
+	baseURL := "http://localhost:4010"
+	if envURL, ok := os.LookupEnv("TEST_API_BASE_URL"); ok {
+		baseURL = envURL
+	}
+	if !testutil.CheckTestServer(t, baseURL) {
+		return
+	}
+	client := courier.NewClient(
+		option.WithBaseURL(baseURL),
+		option.WithAPIKey("My API Key"),
+	)
+	_, err := client.Journeys.Runs.ListSteps(context.TODO(), "x")
+	if err != nil {
+		var apierr *courier.Error
+		if errors.As(err, &apierr) {
+			t.Log(string(apierr.DumpRequest(true)))
+		}
+		t.Fatalf("err should be nil: %s", err.Error())
+	}
+}


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

**5 endpoint(s) added**

- `GET /automations/runs` — List Automation runs
- `GET /automations/runs/{id}/steps` — List steps for an Automation run
- `GET /journeys/runs` — List Journey runs
- `GET /journeys/runs/{run_id}` — Fetch a Journey run
- `GET /journeys/runs/{run_id}/steps` — List steps for a Journey run


## What changed in this SDK

8 files changed, 943 insertions(+), 11 deletions(-)

<details><summary>Files</summary>

```
 .stats.yml            |   2 +-
 api.md                |  29 +++++
 automation.go         | 111 +++++++++++++++++
 automationrun.go      |  94 +++++++++++++++
 automationrun_test.go |  67 +++++++++++
 journey.go            | 452 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++--
 journeyrun.go         | 109 +++++++++++++++++
 journeyrun_test.go    |  90 ++++++++++++++
 8 files changed, 943 insertions(+), 11 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
